### PR TITLE
Add Pull Request Template, copied from Cypress

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
+
+**Submitter:**
+- [ ] This pull request describes why these changes were made.
+- [ ] Internal ticket for this PR:
+- [ ] Internal ticket links to this PR
+- [ ] Code diff has been done and been reviewed
+- [ ] Tests are included and test edge cases
+- [ ] Tests have been run locally and pass
+
+**Reviewer 1:**
+
+Name:
+- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
+- [ ] The tests appropriately test the new code, including edge cases
+- [ ] You have tried to break the code
+
+**Reviewer 2:**
+
+Name:
+- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
+- [ ] The tests appropriately test the new code, including edge cases
+- [ ] You have tried to break the code


### PR DESCRIPTION
This pull request adds a PR template to `js-ecqm-engine`, so the template you see below automagically gets added to every PR.


**Submitter:** Michael O'Keefe
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/TACO-31
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases N/A
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases N/A
- [ ] You have tried to break the code
