### PR TITLE
Glob json/mustache/rake files as well

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    cqm-parsers (0.1.0)
+    cqm-parsers (0.1.1)
       activesupport (~> 4.2.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '0.1.0'
+  s.version = '0.1.1'
 
   s.add_dependency 'rest-client', '~>1.8.0'
   s.add_dependency 'erubis', '~> 2.7.0'

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'log4r', '~> 1.1.10'
   s.add_dependency 'memoist', '~> 0.9.1'
 
-  s.files = Dir.glob('lib/**/*.rb') + ["Gemfile", "README.md", "Rakefile"]
+  s.files = Dir.glob('lib/**/*.rb') + Dir.glob('lib/**/*.json') + Dir.glob('lib/**/*.mustache') + Dir.glob('lib/**/*.rake') + ["Gemfile", "README.md", "Rakefile"]
 end


### PR DESCRIPTION
In order to include them in the gem, add `.json`, `.mustache` and `.rake` files to the `.rb` files already included in `s.files`.

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @rbclark
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
