### PR TITLE
Cat 1 patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec :development_group => :test
 
 gem 'mustache'
-gem 'cqm-models', '~> 0.8.2'
+gem 'cqm-models', '~> 0.8.4'
 gem 'mongoid', '~> 5.0.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       nokogiri (~> 1.8.3)
       protected_attributes (~> 1.0.5)
       rest-client (~> 1.8.0)
-      rubyzip (~> 1.2.1)
+      rubyzip (~> 1.2.2)
       uuid (~> 2.3.7)
       zip-zip (~> 0.3)
 
@@ -51,7 +51,7 @@ GEM
     cane (2.3.0)
       parallel
     concurrent-ruby (1.0.5)
-    cqm-models (0.8.2)
+    cqm-models (0.8.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.3.1)
@@ -90,12 +90,12 @@ GEM
     mime-types (2.99.3)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    minitest-reporters (1.3.0)
+    minitest-reporters (1.3.4)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mongo (2.6.1)
+    mongo (2.6.2)
       bson (>= 4.3.0, < 5.0.0)
     mongoid (5.0.2)
       activemodel (~> 4.0)
@@ -115,7 +115,7 @@ GEM
     powerpack (0.1.2)
     protected_attributes (1.0.9)
       activemodel (>= 4.0.1, < 5.0)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
     rainbow (3.0.0)
     rake (12.3.1)
     rest-client (1.8.0)
@@ -129,8 +129,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
-    rubyzip (1.2.1)
+    ruby-progressbar (1.10.0)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -172,7 +172,7 @@ DEPENDENCIES
   bundler-audit
   byebug (~> 6.0.2)
   cane (~> 2.3.0)
-  cqm-models (~> 0.8.2)
+  cqm-models (~> 0.8.4)
   cqm-parsers!
   factory_girl (~> 4.1.0)
   minitest (~> 5.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    cqm-parsers (0.1.1)
+    cqm-parsers (0.2.0)
       activesupport (~> 4.2.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '0.1.1'
+  s.version = '0.2.0'
 
   s.add_dependency 'rest-client', '~>1.8.0'
   s.add_dependency 'erubis', '~> 2.7.0'

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '~> 1.8.3'
   s.add_dependency 'highline', "~> 1.7.0"
 
-  s.add_dependency 'rubyzip', '~> 1.2.1'
+  s.add_dependency 'rubyzip', '~> 1.2.2'
   s.add_dependency 'zip-zip', '~> 0.3'
 
   s.add_dependency 'log4r', '~> 1.1.10'

--- a/lib/qrda-export/catI-r5/_header.mustache
+++ b/lib/qrda-export/catI-r5/_header.mustache
@@ -4,11 +4,11 @@
 <!-- US Realm Header Template Id -->
 <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
 <!-- QRDA templateId -->
-<templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2016-02-01"/>
+<templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2017-08-01"/>
 <!-- QDM-based QRDA templateId -->
-<templateId root="2.16.840.1.113883.10.20.24.1.2" extension="2016-02-01"/>
+<templateId root="2.16.840.1.113883.10.20.24.1.2" extension="2017-08-01"/>
 <!-- CMS QRDA templateId -->
-<templateId root="2.16.840.1.113883.10.20.24.1.3" extension="2017-07-01" />
+<templateId root="2.16.840.1.113883.10.20.24.1.3" extension="2018-02-01"/>
 <!-- This is the globally unique identifier for this QRDA document -->
 <id root="{{random_id}}"/>
 <!-- QRDA document type code -->

--- a/lib/qrda-export/catI-r5/_header.mustache
+++ b/lib/qrda-export/catI-r5/_header.mustache
@@ -15,7 +15,7 @@
 <code code="55182-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Measure Report"/>
 <title>QRDA Incidence Report</title>
 <!-- This is the document creation time -->
-<effectiveTime value="20180524170839"/>
+<effectiveTime value="{{{current_time}}}"/>
 <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
 <languageCode code="en"/>
 <!-- reported patient -->

--- a/lib/qrda-export/catI-r5/qrda1_r5.mustache
+++ b/lib/qrda-export/catI-r5/qrda1_r5.mustache
@@ -13,7 +13,7 @@
           <templateId root="2.16.840.1.113883.10.20.17.2.4"/>
           <!-- This is the templateId for Patient Data QDM section -->
           <templateId extension="2017-08-01" root="2.16.840.1.113883.10.20.24.2.1"/>
-          <templateId extension="2017-07-01" root="2.16.840.1.113883.10.20.24.2.1.1"/>
+          <templateId extension="2018-02-01" root="2.16.840.1.113883.10.20.24.2.1.1"/>
           <code code="55188-7" codeSystem="2.16.840.1.113883.6.1"/>
           <title>Patient Data</title>
           <text/>

--- a/lib/qrda-export/catI-r5/qrda1_r5.rb
+++ b/lib/qrda-export/catI-r5/qrda1_r5.rb
@@ -16,110 +16,110 @@ class Qrda1R5 < Mustache
   end
 
   def adverse_event
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.10.20.28.3.120').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('adverse_event', '') }).to_json)
   end
 
   def allergy_intolerance
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.10.20.28.3.119').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('allergy_intolerance', '') }).to_json)
   end
 
   def assessment_performed
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.10.20.28.3.117').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('assessment', 'performed') }).to_json)
   end
 
   def communication_from_patient_to_provider
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.3.560.1.30').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('communication_from_patient_to_provider', '') }).to_json)
   end
 
   def communication_from_provider_to_patient
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.31','2.16.840.1.113883.3.560.1.131'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('communication_from_provider_to_patient', '') }).to_json)
   end
 
   def communication_from_provider_to_provider
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.29','2.16.840.1.113883.3.560.1.129'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('communication_from_provider_to_provider', '') }).to_json)
   end
 
   def diagnosis
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.10.20.28.3.110').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('diagnosis', '') }).to_json)
   end
 
   def device_ordered
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.37','2.16.840.1.113883.3.560.1.137'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('device', 'ordered') }).to_json)
   end
 
   def device_applied
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.10','2.16.840.1.113883.3.560.1.110'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('device', 'applied') }).to_json)
   end
 
   def diagnostic_study_ordered
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.40','2.16.840.1.113883.3.560.1.140'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('diagnostic_study', 'ordered') }).to_json)
   end
 
   def diagnostic_study_performed
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.103','2.16.840.1.113883.3.560.1.3'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('diagnostic_study', 'performed') }).to_json)
   end
 
   def encounter_ordered
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.3.560.1.83').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('encounter', 'ordered') }).to_json)
   end
 
   def encounter_performed
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.3.560.1.79').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('encounter', 'performed') }).to_json)
   end
 
   def immunization_aministered
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.10.20.28.3.112'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('immunization', 'aministered') }).to_json)
   end
 
   def intervention_ordered
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.45','2.16.840.1.113883.3.560.1.145'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('intervention', 'ordered') }).to_json)
   end
 
   def intervention_performed
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.46','2.16.840.1.113883.3.560.1.146'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('intervention', 'performed') }).to_json)
   end
 
   def lab_test_performed
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.3.560.1.5').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('laboratory_test', 'performed') }).to_json)
   end
 
   def lab_test_ordered
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.50','2.16.840.1.113883.3.560.1.150'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('laboratory_test', 'ordered') }).to_json)
   end
 
   def medication_active
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.3.560.1.13').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'active') }).to_json)
   end
 
   def medication_administered
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.14','2.16.840.1.113883.3.560.1.64','2.16.840.1.113883.3.560.1.114'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'administered') + HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('substance', 'administered') }).to_json)
   end
 
   def medication_discharge
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.199','2.16.840.1.113883.3.560.1.200'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'discharge') }).to_json)
   end
 
   def medication_dispensed
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.3.560.1.8').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'dispensed') }).to_json)
   end
 
   def medication_ordered
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.78','2.16.840.1.113883.3.560.1.17'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'ordered') }).to_json)
   end
 
   def patient_characteristic_expired
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.10.20.28.3.57').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('patient_characteristic_expired', '') }).to_json)
   end
   
   def physical_exam_performed
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.57','2.16.840.1.113883.3.560.1.157'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('physical_exam', 'performed') }).to_json)
   end
 
   def procedure_ordered
-    JSON.parse(@patient.dataElements.where(hqmfOid: '2.16.840.1.113883.3.560.1.62').to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('procedure', 'ordered') }).to_json)
   end
 
   def procedure_performed
-    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => ['2.16.840.1.113883.3.560.1.6','2.16.840.1.113883.3.560.1.106'] }).to_json)
+    JSON.parse(@patient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('procedure', 'performed') }).to_json)
   end
 end

--- a/lib/qrda-export/catI-r5/qrda_header/_author.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_author.mustache
@@ -1,9 +1,13 @@
 <author>
   <time value="20180524170839"/>
   <assignedAuthor>
-    <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
     <!-- NPI -->
-    <id extension="1982671962" root="2.16.840.1.113883.4.6"/>
+    {{#provider}}
+      <id extension="{{{provider_npi}}}" root="2.16.840.1.113883.4.6"/>
+    {{/provider}}
+    {{^provider}}
+      <id extension="1982671962" root="2.16.840.1.113883.4.6"/>
+    {{/provider}}
     <addr>
       <streetAddressLine>202 Burlington Rd.</streetAddressLine>
       <city>Bedford</city>

--- a/lib/qrda-export/catI-r5/qrda_header/_author.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_author.mustache
@@ -1,5 +1,5 @@
 <author>
-  <time value="20180524170839"/>
+  <time value="{{{current_time}}}"/>
   <assignedAuthor>
     <!-- NPI -->
     {{#provider}}

--- a/lib/qrda-export/catI-r5/qrda_header/_custodian.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_custodian.mustache
@@ -1,7 +1,32 @@
+{{#provider}}
 <custodian>
   <assignedCustodian>
     <representedCustodianOrganization>
-      <!-- HQR Only -->
+      {{#provider_ccn}}
+        <id extension="{{{provider_ccn}}}" root="2.16.840.1.113883.4.336"/>
+      {{/provider_ccn}}
+      {{^provider_ccn}}
+        <id extension="800890" root="2.16.840.1.113883.4.336"/>
+      {{/provider_ccn}}
+      <name>Cypress Test Deck</name>
+      <telecom use="WP" value="tel:(781)271-3000"/>
+      {{#provider_addresses}}
+        <addr use="HP">
+          <streetAddressLine>{{{provider_street}}}</streetAddressLine>
+          <city>{{{city}}}</city>
+          <state>{{{state}}}</state>
+          <postalCode>{{{zip}}}</postalCode>
+          <country>{{{country}}}</country>
+        </addr>
+      {{/provider_addresses}}
+    </representedCustodianOrganization>
+  </assignedCustodian>
+</custodian>
+{{/provider}}
+{{^provider}}
+<custodian>
+  <assignedCustodian>
+    <representedCustodianOrganization>
       <id extension="800890" root="2.16.840.1.113883.4.336"/>
       <name>Cypress Test Deck</name>
       <telecom use="WP" value="tel:(781)271-3000"/>
@@ -15,3 +40,4 @@
     </representedCustodianOrganization>
   </assignedCustodian>
 </custodian>
+{{/provider}}

--- a/lib/qrda-export/catI-r5/qrda_header/_documentation_of_service_event.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_documentation_of_service_event.mustache
@@ -14,7 +14,9 @@
       {{#provider}}
       <assignedEntity>
         <id extension="{{{provider_npi}}}" root="2.16.840.1.113883.4.6"/>
-        <id extension="{{{provider_ccn}}}" root="2.16.840.1.113883.4.336"/>
+        {{#provider_ccn}}
+          <id extension="{{{provider_ccn}}}" root="2.16.840.1.113883.4.336"/>
+        {{/provider_ccn}}
         <code code="{{{provider_type_code}}}" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
         {{#provider_addresses}}
         <addr use="HP">

--- a/lib/qrda-export/catI-r5/qrda_header/_legal_authenticator.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_legal_authenticator.mustache
@@ -1,5 +1,5 @@
 <legalAuthenticator>
-  <time value="20180524170839"/>
+  <time value="{{{current_time}}}"/>
   <signatureCode code="S"/>
   <assignedEntity>
     <id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>

--- a/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
@@ -17,8 +17,8 @@
       </name>
       <administrativeGenderCode code="{{{gender}}}" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 AdministrativeGender"/>
       <birthTime value="{{{birthdate}}}"/>
-      <raceCode code="{{{race}}}" displayName="Black or African American" codeSystemName="CDC Race and Ethnicity" codeSystem="2.16.840.1.113883.6.238"/>
-      <ethnicGroupCode code="{{{ethnic_group}}}" displayName="Not Hispanic or Latino" codeSystemName="CDC Race and Ethnicity" codeSystem="2.16.840.1.113883.6.238"/>
+      <raceCode code="{{{race}}}" codeSystemName="CDC Race and Ethnicity" codeSystem="2.16.840.1.113883.6.238"/>
+      <ethnicGroupCode code="{{{ethnic_group}}}" codeSystemName="CDC Race and Ethnicity" codeSystem="2.16.840.1.113883.6.238"/>
       <languageCommunication>
         <templateId root="2.16.840.1.113883.3.88.11.83.2" assigningAuthorityName="HITSP/C83"/>
         <templateId root="1.3.6.1.4.1.19376.1.5.3.1.2.1" assigningAuthorityName="IHE/PCC"/>

--- a/lib/qrda-export/catI-r5/qrda_templates/device_ordered.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/device_ordered.mustache
@@ -22,10 +22,10 @@
             </playingDevice>
           </participantRole>
         </participant>
+        {{#negationRationale}}
+        {{> qrda_templates/template_partials/_reason}}
+        {{/negationRationale}}
       </supply>
     </entryRelationship>
-    {{#negationRationale}}
-    {{> qrda_templates/template_partials/_reason}}
-    {{/negationRationale}}  
   </act>
 </entry>

--- a/lib/qrda-export/catI-r5/qrda_templates/encounter_ordered.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/encounter_ordered.mustache
@@ -16,10 +16,10 @@
         {{#authorDatetime}}
         {{> qrda_templates/template_partials/_author}}
         {{/authorDatetime}}
+        {{#negationRationale}}
+        {{> qrda_templates/template_partials/_reason}}
+        {{/negationRationale}}
       </encounter>
     </entryRelationship>
-    {{#negationRationale}}
-    {{> qrda_templates/template_partials/_reason}}
-    {{/negationRationale}}
   </act>
 </entry>

--- a/lib/qrda-export/catI-r5/qrda_templates/medication_discharge.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/medication_discharge.mustache
@@ -46,10 +46,10 @@
         {{#authorDatetime}}
         {{> qrda_templates/template_partials/_author_participation}}
         {{/authorDatetime}}
+        {{#negationRationale}}
+        {{> qrda_templates/template_partials/_reason}}
+        {{/negationRationale}} 
       </substanceAdministration>
     </entryRelationship>
-    {{#negationRationale}}
-    {{> qrda_templates/template_partials/_reason}}
-    {{/negationRationale}} 
   </act>
 </entry>

--- a/lib/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
@@ -30,10 +30,10 @@
         {{#authorDatetime}}
         {{> qrda_templates/template_partials/_author}}
         {{/authorDatetime}}
+        {{#negationRationale}}
+        {{> qrda_templates/template_partials/_reason}}
+        {{/negationRationale}}
       </supply>
     </entryRelationship>
-    {{#negationRationale}}
-    {{> qrda_templates/template_partials/_reason}}
-    {{/negationRationale}} 
   </act>
 </entry>

--- a/lib/qrda-export/helper/cat_1_view_helper.rb
+++ b/lib/qrda-export/helper/cat_1_view_helper.rb
@@ -7,11 +7,11 @@ module Qrda
         end
 
         def as_id
-          self['$oid']
+          self[:value]
         end
 
         def object_id
-          self[:_id]['$oid']
+          self[:_id]
         end
 
         def submission_program

--- a/lib/qrda-export/helper/date_helper.rb
+++ b/lib/qrda-export/helper/date_helper.rb
@@ -19,6 +19,10 @@ module Qrda
           @performance_period_end.to_formatted_s(:number)
         end
 
+        def current_time
+          Time.now.utc.to_formatted_s(:number)
+        end
+
         def author_time
           "<time #{value_or_null_flavor(self['authorDatetime'])}/>"
         end

--- a/lib/qrda-import/base-importers/demographics_importer.rb
+++ b/lib/qrda-import/base-importers/demographics_importer.rb
@@ -2,11 +2,8 @@ module QRDA
   module Cat1
     module DemographicsImporter
       def get_demographics(patient, doc)
-        # effective_date = doc.at_xpath('/cda:ClinicalDocument/cda:effectiveTime')['value']
-        # patient.effective_time = HL7Helper.timestamp_to_integer(effective_date)
         patient_role_element = doc.at_xpath('/cda:ClinicalDocument/cda:recordTarget/cda:patientRole')
         patient_element = patient_role_element.at_xpath('./cda:patient')
-        # patient.title = patient_element.at_xpath('cda:name/cda:title').try(:text)
         patient.givenNames = [patient_element.at_xpath('cda:name/cda:given').text]
         patient.familyName = patient_element.at_xpath('cda:name/cda:family').text
         patient.birthDatetime = Time.parse(patient_element.at_xpath('cda:birthTime')['value']).utc
@@ -20,27 +17,26 @@ module QRDA
         pcs.dataElementCodes = [{ code: gender_code, codeSystem: 'AdministrativeGender' }]
         patient.dataElements << pcs
 
-        # TODO: Investigate what of this HDS import codes needs to be addressed in this qrda parser.
-        # gender_node = patient_element.at_xpath('cda:administrativeGenderCode')
-        # patient.gender = gender_node['code']
-        # id_node = patient_role_element.at_xpath('./cda:id')
-        # patient.medical_record_number = id_node['extension']
-        
-        # parse race, ethnicity, and spoken language
-        # race_node = patient_element.at_xpath('cda:raceCode')
-        # patient.race = { 'code' => race_node['code'], 'codeSystem' => 'CDC Race' } if race_node
-        # ethnicity_node = patient_element.at_xpath('cda:ethnicGroupCode')
-        # patient.ethnicity = {'code' => ethnicity_node['code'], 'codeSystem' => 'CDC Race'} if ethnicity_node
-        # marital_status_node = patient_element.at_xpath("./cda:maritalStatusCode")
-        # patient.marital_status = {code: marital_status_node['code'], code_set: "HL7 Marital Status"} if marital_status_node
-        # ra_node = patient_element.at_xpath("./cda:religiousAffiliationCode")
-        # patient.religious_affiliation = {code: ra_node['code'], code_set: "Religious Affiliation"} if ra_node
-        # languages = patient_element.search('languageCommunication').map {|lc| lc.at_xpath('cda:languageCode')['code'] }
-        # patient.languages = languages unless languages.empty?
-        
-        # patient.addresses = patient_role_element.xpath("./cda:addr").map { |addr| import_address(addr) }
-        # patient.telecoms = patient_role_element.xpath("./cda:telecom").map { |tele| import_telecom(tele) }
-        
+        pcr = QDM::PatientCharacteristicRace.new
+        race_code = patient_element.at_xpath('cda:raceCode')['code']
+        pcr.dataElementCodes = [{ code: race_code, codeSystem: 'cdcrec' }]
+        patient.dataElements << pcr
+
+        pce = QDM::PatientCharacteristicEthnicity.new
+        ethnicity_code = patient_element.at_xpath('cda:ethnicGroupCode')['code']
+        pce.dataElementCodes = [{ code: ethnicity_code, codeSystem: 'cdcrec' }]
+        patient.dataElements << pce
+
+        provider_element = doc.xpath("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.55']")
+
+        # If a provider element isn't in the record, return wiihout adding one.
+        return if provider_element.blank?
+        provider_code = provider_element.first.at_xpath('cda:value')['code']
+        ip = {}
+        ip['financial_responsibility_type'] = { 'code' => 'SELF', 'codeSystem' => 'HL7 Relationship Code' }
+        ip['codes'] = { 'SOP' => [provider_code] }
+        patient.extendedData = {}
+        patient.extendedData['insurance_providers'] = JSON.generate([ip])
       end
     end
   end

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -38,8 +38,8 @@ module QRDA
 
       def create_entry(entry_element, _nrh = NarrativeReferenceHandler.new)
         entry = @entry_class.new
-        @entry_id_map[extract_id(entry_element, "./cda:id")] ||= []
-        @entry_id_map[extract_id(entry_element, "./cda:id")] << entry.id
+        @entry_id_map[extract_id(entry_element, "./cda:id").value] ||= []
+        @entry_id_map[extract_id(entry_element, "./cda:id").value] << entry.id
         entry.dataElementCodes = extract_codes(entry_element, @code_xpath)
         extract_dates(entry_element, entry)
         if @result_xpath
@@ -54,9 +54,9 @@ module QRDA
       def extract_id(parent_element, id_xpath)
         id_element = parent_element.at_xpath(id_xpath)
         return unless id_element
-        identifier = CDAIdentifier.new
-        identifier.root = id_element['root']
-        identifier.extension = id_element['extension']
+        # If an extension is not included, use the root as the value.  Other wise use the extension
+        value = id_element['extension'] ? id_element['extension'] : id_element['root']
+        identifier = QDM::Id.new(value: value, namingSystem: id_element['root'])
         identifier
       end
 

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -133,13 +133,13 @@ module QRDA
       # coded_parent_element is the 'parent' element when the coded is nested (e.g., medication order)
       def extract_reason_or_negation(parent_element, entry, coded_parent_element = nil)
         coded_parent_element ||= parent_element
-        reason_element = parent_element.at_xpath("./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value | ./cda:entryRelationship[@typeCode='RSON']/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.1.27']/cda:code")
+        reason_element = parent_element.xpath(".//cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value | .//cda:entryRelationship[@typeCode='RSON']/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.1.27']/cda:code")
         negation_indicator = parent_element['negationInd']
-        if reason_element
+        unless reason_element.blank?
           if negation_indicator.eql?('true')
-            entry.negationRationale = code_if_present(reason_element)
+            entry.negationRationale = code_if_present(reason_element.first)
           else
-            entry.reason = code_if_present(reason_element)
+            entry.reason = code_if_present(reason_element.first)
           end
         end
         extract_negated_code(coded_parent_element, entry)

--- a/lib/qrda-import/patient_importer.rb
+++ b/lib/qrda-import/patient_importer.rb
@@ -89,8 +89,14 @@ module QRDA
 
       def normalize_references(patient, entry_id_map)
         patient.dataElements.each do |data_element|
-          if data_element.respond_to?(:relatedTo) && data_element.relatedTo
-            data_element.relatedTo.map! { |related_to| entry_id_map[related_to] }
+          next unless data_element.respond_to?(:relatedTo) && data_element.relatedTo
+          relations_to_add = []
+          data_element.relatedTo.each do |related_to|
+            relations_to_add << entry_id_map[related_to.value]
+          end
+          data_element.relatedTo.destroy
+          relations_to_add.each do |relation_to_add|
+            data_element.relatedTo << relation_to_add
           end
         end
       end

--- a/lib/util/hqmf_template_helper.rb
+++ b/lib/util/hqmf_template_helper.rb
@@ -34,6 +34,19 @@ module HQMF
           nil
         end
       end
+
+      # Returns a list of all hqmf_oids (regardless of version) for the combination of definition and status
+      def self.get_all_hqmf_oids(definition, status)
+        status ||= ""
+        version_negation_combinations = [{ version: 'r1', negation: false },
+                                         { version: 'r1', negation: true },
+                                         { version: 'r2', negation: false },
+                                         { version: 'r2cql', negation: false }]
+        hqmf_oids = version_negation_combinations.collect do |obj|
+          template_id_by_definition_and_status(definition, status, obj[:negation], obj[:version])
+        end
+        hqmf_oids
+      end
     end
   end
 end


### PR DESCRIPTION
Add helper method for current time
Updates to QRDA header templateid extensions (found in HDS QRDA5 export by bonnie)
Import race, ethnicity, payer.
only export CCN when available
A Reason can be nested in a wrapped template (on import and export)
When provider information is available, use in export.  otherwise boilerplate
Update to use the QDM::ID
Race and ethnicGroupCode display name were exporting a fixed value
On export, look up all appropriate HQMF ids for a definition/status pair, not fixed values (they can change over time)


**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
