### PR TITLE
Including mustache dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gemspec :development_group => :test
 
-gem 'mustache'
 gem 'cqm-models', '~> 0.8.4'
 gem 'mongoid', '~> 5.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ DEPENDENCIES
   minitest (~> 5.3)
   minitest-reporters
   mongoid (~> 5.0.0)
+  mustache
   rake
   rubocop (~> 0.52.1)
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ PATH
       memoist (~> 0.9.1)
       mongoid (~> 5.0.0)
       mongoid-tree (~> 2.0.0)
+      mustache
       nokogiri (~> 1.8.5)
       protected_attributes (~> 1.0.5)
       rest-client (~> 1.8.0)
@@ -178,7 +179,6 @@ DEPENDENCIES
   minitest (~> 5.3)
   minitest-reporters
   mongoid (~> 5.0.0)
-  mustache
   rake
   rubocop (~> 0.52.1)
   simplecov
@@ -187,4 +187,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.3
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,6 @@ DEPENDENCIES
   minitest (~> 5.3)
   minitest-reporters
   mongoid (~> 5.0.0)
-  mustache
   rake
   rubocop (~> 0.52.1)
   simplecov

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -10,7 +10,8 @@ Gem::Specification.new do |s|
   s.license = 'Apache-2.0'
 
   s.version = '0.2.1'
-
+  
+  s.add_dependency 'mustache'
   s.add_dependency 'rest-client', '~>1.8.0'
   s.add_dependency 'erubis', '~> 2.7.0'
   s.add_dependency 'mongoid', '~> 5.0.0'

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license = 'Apache-2.0'
 
   s.version = '0.2.1'
-  
+
   s.add_dependency 'mustache'
   s.add_dependency 'rest-client', '~>1.8.0'
   s.add_dependency 'erubis', '~> 2.7.0'


### PR DESCRIPTION
Updating gemspec with mustache dependency.

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1827
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @daco101 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:@mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
