### PR TITLE
Set up codecov code coverage tool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec :development_group => :test
 
@@ -17,8 +17,9 @@ end
 
 group :test do
   gem 'factory_girl', '~> 4.1.0'
-  gem "tailor", '~> 1.1.2'
-  gem "cane", '~> 2.3.0'
+  gem 'tailor', '~> 1.1.2'
+  gem 'cane', '~> 2.3.0'
+  gem 'codecov'
   gem 'simplecov', :require => false
   gem 'webmock'
   gem 'minitest', '~> 5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,10 @@ GEM
     byebug (6.0.2)
     cane (2.3.0)
       parallel
+    codecov (0.1.14)
+      json
+      simplecov
+      url
     concurrent-ruby (1.0.5)
     cqm-models (0.8.4)
     crack (0.4.3)
@@ -156,6 +160,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.0)
+    url (0.3.2)
     uuid (2.3.9)
       macaddr (~> 1.0)
     vcr (3.0.3)
@@ -174,6 +179,7 @@ DEPENDENCIES
   bundler-audit
   byebug (~> 6.0.2)
   cane (~> 2.3.0)
+  codecov
   cqm-models (~> 0.8.4)
   cqm-parsers!
   factory_girl (~> 4.1.0)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![codecov](https://codecov.io/gh/projecttacoma/cqm-parsers/branch/master/graph/badge.svg)](https://codecov.io/gh/projecttacoma/cqm-parsers)
+
+
 cqm-parsers
 ===========
 

--- a/test/simplecov_init.rb
+++ b/test/simplecov_init.rb
@@ -1,21 +1,8 @@
 require 'simplecov'
+require 'codecov'
 SimpleCov.start do
   add_filter "test/"
   track_files 'lib/**/*.rb'
 end
 
-module SimpleCov
-  module Formatter
-    class QualityFormatter
-      def format(result)
-        SimpleCov::Formatter::HTMLFormatter.new.format(result)
-        File.open("coverage/covered_percent", "w") do |f|
-          f.puts result.source_files.covered_percent.to_f
-        end
-      end
-    end
-  end
-end
-
-SimpleCov.formatter = SimpleCov::Formatter::QualityFormatter
-SimpleCov.minimum_coverage(82.77)
+SimpleCov.formatter = SimpleCov::Formatter::Codecov


### PR DESCRIPTION
Set up codecov for code coverage.

To see this branch's coverage, go to https://codecov.io/gh/projecttacoma/cqm-parsers/branch/codecov

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1867
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
