### PR TITLE
Remove bonnie id

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
@@ -1,6 +1,5 @@
 <recordTarget>
   <patientRole>
-    <id extension="{{mrn}}" root="Bonnie"/>
     <id extension="{{mrn}}" root="1.3.6.1.4.1.115" />
     <addr use="HP">
       <streetAddressLine>202 Burlington Rd.</streetAddressLine>


### PR DESCRIPTION
There were 2 IDs in the "recordTarget" section of QRDA template, remove the one that was set to "Bonnie"

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-392
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases N/A
- [x] You have tried to break the code
