### PR TITLE
Id import

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/encounter_ordered.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/encounter_ordered.mustache
@@ -1,7 +1,6 @@
 <entry>
   <act classCode="ACT" moodCode="RQO" {{{negation_ind}}}>
     <templateId root="2.16.840.1.113883.10.20.24.3.132" extension="2017-08-01"/>
-    <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">
       <encounter classCode="ENC" moodCode="RQO">

--- a/lib/qrda-export/catI-r5/qrda_templates/encounter_performed.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/encounter_performed.mustache
@@ -2,7 +2,6 @@
   <act classCode="ACT" moodCode="EVN">
     <!--Encounter performed Act -->
     <templateId extension="2017-08-01" root="2.16.840.1.113883.10.20.24.3.133"/>
-    <id extension="{{object_id}}" root="1.3.6.1.4.1.115"/>
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" codeSystemName="ActClass" displayName="Encounter"/>
     <entryRelationship typeCode="SUBJ">
       <encounter classCode="ENC" moodCode="EVN">

--- a/lib/qrda-import/base-importers/medication_importer.rb
+++ b/lib/qrda-import/base-importers/medication_importer.rb
@@ -4,6 +4,7 @@ module QRDA
   
       def initialize(entry_finder = nil)
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = "./cda:consumable/cda:manufacturedProduct/cda:manufacturedMaterial/cda:code"
         @relevant_period_xpath = "./cda:effectiveTime"
         @author_datetime_xpath = "./cda:author/cda:time"

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -38,8 +38,8 @@ module QRDA
 
       def create_entry(entry_element, _nrh = NarrativeReferenceHandler.new)
         entry = @entry_class.new
-        @entry_id_map[extract_id(entry_element, "./cda:id").value] ||= []
-        @entry_id_map[extract_id(entry_element, "./cda:id").value] << entry.id
+        @entry_id_map[extract_id(entry_element, @id_xpath).value] ||= []
+        @entry_id_map[extract_id(entry_element, @id_xpath).value] << entry.id
         entry.dataElementCodes = extract_codes(entry_element, @code_xpath)
         extract_dates(entry_element, entry)
         if @result_xpath

--- a/lib/qrda-import/data-element-importers/adverse_event_importer.rb
+++ b/lib/qrda-import/data-element-importers/adverse_event_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class AdverseEventImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.146']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:entryRelationship/cda:observation/cda:value'
         @author_datetime_xpath = './cda:author/cda:time'
         @relevant_period_xpath = './cda:effectiveTime'

--- a/lib/qrda-import/data-element-importers/allergy_intolerance_importer.rb
+++ b/lib/qrda-import/data-element-importers/allergy_intolerance_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class AllergyIntoleranceImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.147']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:participant/cda:participantRole/cda:playingEntity/cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @prevalence_period_xpath = "./cda:effectiveTime"

--- a/lib/qrda-import/data-element-importers/assessment_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/assessment_performed_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class AssessmentPerformedImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.144']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @result_xpath = "./cda:value | ./cda:entryRelationship[@typeCode='REFR']/cda:observation/cda:value"

--- a/lib/qrda-import/data-element-importers/communication_from_patient_to_provider_importer.rb
+++ b/lib/qrda-import/data-element-importers/communication_from_patient_to_provider_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class CommunicationFromPatientToProviderImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @entry_class = QDM::CommunicationFromPatientToProvider

--- a/lib/qrda-import/data-element-importers/communication_from_provider_to_patient_importer.rb
+++ b/lib/qrda-import/data-element-importers/communication_from_provider_to_patient_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class CommunicationFromProviderToPatientImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @entry_class = QDM::CommunicationFromProviderToPatient

--- a/lib/qrda-import/data-element-importers/communication_from_provider_to_provider_importer.rb
+++ b/lib/qrda-import/data-element-importers/communication_from_provider_to_provider_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class CommunicationFromProviderToProviderImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @related_to_xpath = "./sdtc:inFulfillmentOf1/sdtc:actReference"

--- a/lib/qrda-import/data-element-importers/device_applied_importer.rb
+++ b/lib/qrda-import/data-element-importers/device_applied_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class DeviceAppliedImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.7']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:participant/cda:participantRole/cda:playingDevice/cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @relevant_period_xpath = "./cda:effectiveTime"

--- a/lib/qrda-import/data-element-importers/device_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/device_order_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class DeviceOrderImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.130']"))
         super(entry_finder)
+        @id_xpath = './cda:entryRelationship/cda:supply/cda:id'
         @code_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.9']/cda:participant/cda:participantRole/cda:playingDevice/cda:code"
         @author_datetime_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.9']/cda:author/cda:time"
         @entry_class = QDM::DeviceOrder

--- a/lib/qrda-import/data-element-importers/diagnosis_importer.rb
+++ b/lib/qrda-import/data-element-importers/diagnosis_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class DiagnosisImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.137']"))
         super(entry_finder)
+        @id_xpath = './cda:entryRelationship/cda:observation/cda:id'
         @code_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.135']/cda:value"
         @author_datetime_xpath = "./cda:author/cda:time"
         @prevalence_period_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.135']/cda:effectiveTime"

--- a/lib/qrda-import/data-element-importers/diagnostic_study_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/diagnostic_study_order_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class DiagnosticStudyOrderImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.17']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @method_xpath = './cda:methodCode'

--- a/lib/qrda-import/data-element-importers/diagnostic_study_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/diagnostic_study_performed_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class DiagnosticStudyPerformedImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @relevant_period_xpath = "./cda:effectiveTime"
         @author_datetime_xpath = "./cda:author/cda:time"

--- a/lib/qrda-import/data-element-importers/encounter_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/encounter_order_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class EncounterOrderImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.132']"))
         super(entry_finder)
+        @id_xpath = './cda:entryRelationship/cda:encounter/cda:id'
         @code_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']/cda:code"
         @author_datetime_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']/cda:author/cda:time"
         @facility_location_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']/cda:participant[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.100']/cda:participantRole[@classCode='SDLOC']/cda:code"

--- a/lib/qrda-import/data-element-importers/encounter_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/encounter_performed_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class EncounterPerformedImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.133']"))
         super(entry_finder)
+        @id_xpath = './cda:entryRelationship/cda:encounter/cda:id'
         @code_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']/cda:code"
         @relevant_period_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']/cda:effectiveTime"
         @author_datetime_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']/cda:author/cda:time"

--- a/lib/qrda-import/data-element-importers/intervention_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/intervention_order_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class InterventionOrderImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @entry_class = QDM::InterventionOrder

--- a/lib/qrda-import/data-element-importers/intervention_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/intervention_performed_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class InterventionPerformedImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @relevant_period_xpath = "./cda:effectiveTime"
         @author_datetime_xpath = "./cda:author/cda:time"

--- a/lib/qrda-import/data-element-importers/laboratory_test_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/laboratory_test_order_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class LaboratoryTestOrderImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.37']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @method_xpath = './cda:methodCode'

--- a/lib/qrda-import/data-element-importers/laboratory_test_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/laboratory_test_performed_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class LaboratoryTestPerformedImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @relevant_period_xpath = "./cda:effectiveTime"
         @author_datetime_xpath = "./cda:author/cda:time"

--- a/lib/qrda-import/data-element-importers/patient_characteristic_expired.rb
+++ b/lib/qrda-import/data-element-importers/patient_characteristic_expired.rb
@@ -3,6 +3,7 @@ module QRDA
     class PatientCharacteristicExpired < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:value'
         @expired_datetime_xpath = './cda:effectiveTime/cda:low'
         @cause = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.4']/cda:value"

--- a/lib/qrda-import/data-element-importers/physical_exam_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/physical_exam_performed_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class PhysicalExamPerformedImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = "./cda:code"
         @relevant_period_xpath = "./cda:effectiveTime"
         @author_datetime_xpath = "./cda:author/cda:time"

--- a/lib/qrda-import/data-element-importers/procedure_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/procedure_order_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class ProcedureOrderImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.63']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @method_xpath = './cda:methodCode'

--- a/lib/qrda-import/data-element-importers/procedure_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/procedure_performed_importer.rb
@@ -3,6 +3,7 @@ module QRDA
     class ProcedurePerformedImporter < SectionImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']"))
         super(entry_finder)
+        @id_xpath = './cda:id'
         @code_xpath = "./cda:code"
         @relevant_period_xpath = "./cda:effectiveTime"
         @author_datetime_xpath = "./cda:author/cda:time"

--- a/test/fixtures/qrda/0_1 N_GP Adult 2.xml
+++ b/test/fixtures/qrda/0_1 N_GP Adult 2.xml
@@ -340,7 +340,6 @@
   <act classCode="ACT" moodCode="EVN">
     <!--Encounter performed Act -->
     <templateId root="2.16.840.1.113883.10.20.24.3.133" extension="2017-08-01"/>
-    <id root="d57528e0-26f0-0136-9a42-6a00008fee71" />
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">
       <encounter classCode="ENC" moodCode="EVN">

--- a/test/fixtures/qrda/0_1 N_GP Adult 2.xml
+++ b/test/fixtures/qrda/0_1 N_GP Adult 2.xml
@@ -282,7 +282,6 @@
   <act classCode="ACT" moodCode="EVN" >
     <!--Encounter performed Act -->
     <templateId root="2.16.840.1.113883.10.20.24.3.133" extension="2017-08-01"/>
-    <id root="d57528e0-26f0-0136-9a42-6a00008fee70" />
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">
       <encounter classCode="ENC" moodCode="EVN">
@@ -311,7 +310,6 @@
   <act classCode="ACT" moodCode="EVN" >
     <!--Encounter performed Act -->
     <templateId root="2.16.840.1.113883.10.20.24.3.133" extension="2017-08-01"/>
-    <id root="d57528e0-26f0-0136-9a42-6a00008fee70" />
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">
       <encounter classCode="ENC" moodCode="EVN">
@@ -319,7 +317,7 @@
         <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01"/> 
         <!-- Encounter performed template -->
         <templateId root="2.16.840.1.113883.10.20.24.3.23" extension="2017-08-01"/>
-        <id root="1.3.6.1.4.1.115" extension="5ada27b7aeac50e2db23159f"/>
+        <id root="1.3.6.1.4.1.115" extension="5ada27b7aeac50e2db23159e"/>
         <code code="99213" codeSystem="2.16.840.1.113883.6.12" sdtc:valueSet="2.16.840.1.113883.3.600.1916"><originalText>Encounter, Performed: Office Visit</originalText><translation code="99213" codeSystem="2.16.840.1.113883.6.12"/>
 </code>
         <text>Encounter, Performed: Office Visit</text>


### PR DESCRIPTION
Track down issue happening in CYPRESS-1541.
(id missing in the ACT element of Encounter, Performed but we believe that this should not be causing an error since this is no longer mandatory for the Reporting Year 2019 Version of QRDA (R5) despite being required for the previous version (R4))
[https://oncprojectracking.healthit.gov/support/browse/CYPRESS-1541
]

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-390
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: Lauren DiCristofaro
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code