### PR TITLE
Add the hqmf identifier to a statement reference

### DIFF
--- a/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
@@ -40,6 +40,8 @@ module HQMF2CQL
           # The at_xpath(...).values returns an array of a single element.
           # The match returns an array and since we don't want the double quotes we take the second element
           cql_define_function[:function_name] = entry.at_xpath("*/cda:measureObservationDefinition/cda:value/cda:expression").values.first.match('\\"([A-Za-z0-9 ]+)\\"')[1]
+          cql_define_function[:function_aggregation_type] = entry.at_xpath("*/cda:measureObservationDefinition/cda:methodCode/cda:item").attributes['code'].value
+          cql_define_function[:function_hqmf_oid] = entry.at_xpath("*/cda:measureObservationDefinition/cda:id").attributes['root'].value
           # The criteria_reference_id is the id of the measurePopulationCriteria that should be used for this observation function
           measure_population_id = entry.at_xpath("*/cda:measureObservationDefinition/cda:component/cda:criteriaReference/cda:id").attributes['root'].value
           # Get the name of the parameter to the  observation function within the measurePopulationCriteria section

--- a/lib/measure-loader/hqmf_measure_loader.rb
+++ b/lib/measure-loader/hqmf_measure_loader.rb
@@ -38,13 +38,17 @@ module Measures
         # add observation info, note population_sets needs to have been added to the measure by now
         (hqmf_model_hash[:observations] || []).each do |observation|
           observation = CQM::Observation.new(
+            hqmf_id: observation[:function_hqmf_oid],
+            aggregation_type: observation[:function_aggregation_type],
             observation_function: CQM::StatementReference.new(
               library_name: hqmf_model_hash[:cql_measure_library],
-              statement_name: observation[:function_name]
+              statement_name: observation[:function_name],
+              hqmf_id: observation[:function_hqmf_oid]
             ),
             observation_parameter: CQM::StatementReference.new(
               library_name: hqmf_model_hash[:cql_measure_library],
-              statement_name: observation[:parameter]
+              statement_name: observation[:parameter],
+              hqmf_id: observation[:function_hqmf_oid]
             )
           )
           # add observation to each population set
@@ -114,25 +118,25 @@ module Measures
           statement_ref_string = statement_ref.attr('extension')
           case cc.name
           when 'initialPopulationCriteria'
-            ps[:populations][HQMF::PopulationCriteria::IPP] = statement_ref_string
+            ps[:populations][HQMF::PopulationCriteria::IPP] = statement_ref_string + ".#{cc.at_css('id').attr('root')}"
           when 'denominatorCriteria'
-            ps[:populations][HQMF::PopulationCriteria::DENOM] = statement_ref_string
+            ps[:populations][HQMF::PopulationCriteria::DENOM] = statement_ref_string + ".#{cc.at_css('id').attr('root')}"
           when 'numeratorCriteria'
-            ps[:populations][HQMF::PopulationCriteria::NUMER] = statement_ref_string
+            ps[:populations][HQMF::PopulationCriteria::NUMER] = statement_ref_string + ".#{cc.at_css('id').attr('root')}"
           when 'numeratorExclusionCriteria'
-            ps[:populations][HQMF::PopulationCriteria::NUMEX] = statement_ref_string
+            ps[:populations][HQMF::PopulationCriteria::NUMEX] = statement_ref_string + ".#{cc.at_css('id').attr('root')}"
           when 'denominatorExclusionCriteria'
-            ps[:populations][HQMF::PopulationCriteria::DENEX] = statement_ref_string
+            ps[:populations][HQMF::PopulationCriteria::DENEX] = statement_ref_string + ".#{cc.at_css('id').attr('root')}"
           when 'denominatorExceptionCriteria'
-            ps[:populations][HQMF::PopulationCriteria::DENEXCEP] = statement_ref_string
+            ps[:populations][HQMF::PopulationCriteria::DENEXCEP] = statement_ref_string + ".#{cc.at_css('id').attr('root')}"
           when 'measurePopulationCriteria'
-            ps[:populations][HQMF::PopulationCriteria::MSRPOPL] = statement_ref_string
+            ps[:populations][HQMF::PopulationCriteria::MSRPOPL] = statement_ref_string + ".#{cc.at_css('id').attr('root')}"
           when 'measurePopulationExclusionCriteria'
-            ps[:populations][HQMF::PopulationCriteria::MSRPOPLEX] = statement_ref_string
+            ps[:populations][HQMF::PopulationCriteria::MSRPOPLEX] = statement_ref_string + ".#{cc.at_css('id').attr('root')}"
           when 'stratifierCriteria'
             # Ignore Supplemental Data Elements
             next if holds_supplemental_data_elements(cc)
-            ps[:stratifications] << statement_ref_string
+            ps[:stratifications] << statement_ref_string + ".#{cc.at_css('id').attr('root')}"
           when 'supplementalDataElement'
             ps[:supplemental_data_elements] << statement_ref_string
           end
@@ -160,10 +164,11 @@ module Measures
       end
 
       def modelize_statement_ref_string(statement_ref_string)
-        library_name, statement_name = statement_ref_string.split('.', 2)
+        library_name, statement_name, population_hqmf_id = statement_ref_string.split('.', 3)
         return CQM::StatementReference.new(
           library_name: library_name,
-          statement_name: Utilities.remove_enclosing_quotes(statement_name)
+          statement_name: Utilities.remove_enclosing_quotes(statement_name),
+          hqmf_id: population_hqmf_id
         )
       end
 

--- a/lib/measure-loader/hqmf_measure_loader.rb
+++ b/lib/measure-loader/hqmf_measure_loader.rb
@@ -98,6 +98,7 @@ module Measures
 
           ps_hash[:stratifications].each_with_index do |statement_ref_hash, index|
             population_set.stratifications << CQM::Stratification.new(
+              hqmf_id: statement_ref_hash[:hqmf_id],
               stratification_id: "#{population_set.population_set_id}_Stratification_#{index+1}",
               title: "PopSet#{pop_index+1} Stratification #{index+1}",
               statement: CQM::StatementReference.new(statement_ref_hash)

--- a/test/unit/measure-loader/cql_loader_test.rb
+++ b/test/unit/measure-loader/cql_loader_test.rb
@@ -52,23 +52,31 @@ class CQLLoaderTest < Minitest::Test
       assert_equal 'Population Criteria Section', population_set.title
       assert population_set.populations.instance_of?(CQM::ContinuousVariablePopulationMap)
       assert_equal 'Initial Population', population_set.populations.IPP.statement_name
+      assert_equal '93C1E91C-806B-4F57-946D-D145D1BD08E2', population_set.populations.IPP.hqmf_id
       assert_equal 'Measure Population', population_set.populations.MSRPOPL.statement_name
+      assert_equal '4725E77E-3D0F-46AC-A175-8DEFDE19EC8A', population_set.populations.MSRPOPL.hqmf_id
       assert_equal 'Measure Population Exclusions', population_set.populations.MSRPOPLEX.statement_name
+      assert_equal '31E49A75-5D9F-441D-96D0-FE2FED1B006B', population_set.populations.MSRPOPLEX.hqmf_id
 
       # check stratifications
       assert_equal 2, population_set.stratifications.size
       assert_equal 'PopulationSet_1_Stratification_1', population_set.stratifications[0].stratification_id
       assert_equal 'PopSet1 Stratification 1', population_set.stratifications[0].title
+      assert_equal '4DB7BC72-5DD8-4EEB-AB62-D039567CF620', population_set.stratifications[0].hqmf_id
       assert_equal 'Stratification 1', population_set.stratifications[0].statement.statement_name
+      assert_equal '4DB7BC72-5DD8-4EEB-AB62-D039567CF620', population_set.stratifications[0].statement.hqmf_id
       assert_equal 'MedianAdmitDecisionTimetoEDDepartureTimeforAdmittedPatients', population_set.stratifications[0].statement.library_name
       assert_equal 'PopulationSet_1_Stratification_2', population_set.stratifications[1].stratification_id
       assert_equal 'PopSet1 Stratification 2', population_set.stratifications[1].title
+      assert_equal '46958FCE-9FF3-4F1A-89AB-0A21D1F47F52', population_set.stratifications[1].hqmf_id
       assert_equal 'Stratification 2', population_set.stratifications[1].statement.statement_name
+      assert_equal '46958FCE-9FF3-4F1A-89AB-0A21D1F47F52', population_set.stratifications[1].statement.hqmf_id
       assert_equal 'MedianAdmitDecisionTimetoEDDepartureTimeforAdmittedPatients', population_set.stratifications[1].statement.library_name
 
       # check observation
       assert_equal population_set.observations.size, 1
       assert_equal 'Measure Observation', population_set.observations[0].observation_function.statement_name
+      assert_equal '2D7701F3-F93D-4994-84F6-0FA00FAA81C9', population_set.observations[0].hqmf_id
       assert_equal 'Measure Population', population_set.observations[0].observation_parameter.statement_name
 
       # check SDE


### PR DESCRIPTION
This is a work in progress for populating the hqmf_identifiers for the populations in a population set.  suggest someone more familar with the code base review/modify accordingly.

relates to https://github.com/projecttacoma/cqm-models/pull/85

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code