### PR TITLE
Conditionally load Valuesets from VSAC

### DIFF
--- a/lib/measure-loader/cql_loader.rb
+++ b/lib/measure-loader/cql_loader.rb
@@ -3,12 +3,11 @@ module Measures
 
     # Set store_valueset to false if you do not want to load Value Sets directly from VSAC
     # By default, CQL Loader will load Value Sets from VSAC.
-    def initialize(measure_zip, measure_details, value_set_loader = nil, store_valueset = true)
+    def initialize(measure_zip, measure_details, value_set_loader = nil)
       @measure_zip = measure_zip
       @measure_details = measure_details.deep_symbolize_keys
-      @store_valueset = store_valueset
       @vs_model_cache = {}
-      return unless store_valueset
+      return unless value_set_loader
       value_set_loader.vs_model_cache = @vs_model_cache
       @value_set_loader = value_set_loader
     end
@@ -107,7 +106,7 @@ module Measures
 
       elms = measure.cql_libraries.map(&:elm)
 
-      if @store_valueset
+      if @value_set_loader
         elm_valuesets = ValueSetHelpers.unique_list_of_valuesets_referenced_by_elms(elms)
         verify_hqmf_valuesets_match_elm_valuesets(elm_valuesets, hqmf_model)
         value_set_models, all_codes_and_code_names, value_sets_from_single_code_references =

--- a/lib/measure-loader/cql_loader.rb
+++ b/lib/measure-loader/cql_loader.rb
@@ -3,11 +3,12 @@ module Measures
 
     # Set store_valueset to false if you do not want to load Value Sets directly from VSAC
     # By default, CQL Loader will load Value Sets from VSAC.
-    def initialize(measure_zip, measure_details, value_set_loader, store_valueset = true)
+    def initialize(measure_zip, measure_details, value_set_loader = nil, store_valueset = true)
       @measure_zip = measure_zip
       @measure_details = measure_details.deep_symbolize_keys
       @store_valueset = store_valueset
       @vs_model_cache = {}
+      return unless store_valueset
       value_set_loader.vs_model_cache = @vs_model_cache
       @value_set_loader = value_set_loader
     end

--- a/lib/measure-loader/value_set_helpers.rb
+++ b/lib/measure-loader/value_set_helpers.rb
@@ -44,22 +44,6 @@ module Measures
         return value_set_models, all_codes_and_code_names.as_json, value_sets_from_single_code_references
       end
       
-      private
-
-      def get_all_codes_and_code_names(value_sets)
-        all_codes_and_code_names = {}
-        value_sets.each do |value_set|
-          code_sets = {}
-          value_set.concepts.each do |concept|
-            code_sets[concept.code_system_name] ||= []
-            code_sets[concept.code_system_name] << concept.code
-          end
-          all_codes_and_code_names[value_set.oid] = code_sets
-        end
-
-        return all_codes_and_code_names
-      end
-
       # Add single code references by finding the codes from the elm and creating new ValueSet objects
       # With a generated GUID as a fake oid.
       def make_fake_valuesets_from_single_code_references(elms, vs_model_cache)
@@ -89,6 +73,22 @@ module Measures
           end
         end
         return value_sets_from_single_code_references
+      end
+
+      private
+
+      def get_all_codes_and_code_names(value_sets)
+        all_codes_and_code_names = {}
+        value_sets.each do |value_set|
+          code_sets = {}
+          value_set.concepts.each do |concept|
+            code_sets[concept.code_system_name] ||= []
+            code_sets[concept.code_system_name] << concept.code
+          end
+          all_codes_and_code_names[value_set.oid] = code_sets
+        end
+
+        return all_codes_and_code_names
       end
 
     end


### PR DESCRIPTION
This change allows someone using Measures::CqlLoader to indicate whether or not to store the valuesets.  By default, this parameter is set as true.  When true, Measures::CqlLoader runs as it has always. When set as false, Valueset logic is bypassed.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code