### PR TITLE
The reason template extension was updated to 2017-08-01 from 2014-12-01 (PR against v0.2.2)

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_reason.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_reason.mustache
@@ -1,6 +1,6 @@
 <entryRelationship typeCode="RSON">
   <observation classCode="OBS" moodCode="EVN">
-    <templateId root="2.16.840.1.113883.10.20.24.3.88" extension="2014-12-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.88" extension="2017-08-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{random_id}}" />
     <code code="77301-0" codeSystem="2.16.840.1.113883.6.1" displayName="reason" codeSystemName="LOINC"/>
     <statusCode code="completed"/>


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-426
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code