### PR TITLE
codeListId and hqmfOid are both needed for sdc uniqueness

### DIFF
--- a/lib/measure-loader/source_data_criteria_loader.rb
+++ b/lib/measure-loader/source_data_criteria_loader.rb
@@ -12,7 +12,7 @@ module Measures
 
       # We create the sdc in such a way that "negative" ones look positive in our array by now,
       # so using uniq should give us an array of all positive criteria with no duplicates
-      source_data_criteria.uniq!(&:codeListId)
+      source_data_criteria.uniq! { |sdc| "#{sdc.codeListId}_#{sdc.hqmfOid}" }
       return source_data_criteria
     end
 

--- a/test/unit/measure-loader/cql_loader_test.rb
+++ b/test/unit/measure-loader/cql_loader_test.rb
@@ -136,6 +136,13 @@ class CQLLoaderTest < Minitest::Test
       assert_equal 1, measures.length
       measure = measures[0]
 
+      # when the same valueset is used for multiple source data criteria, make sure both are saved.
+      intervention_dc = measure.source_data_criteria.select { |sdc| sdc.codeListId == '2.16.840.1.113762.1.4.1108.15' }
+      assert_equal intervention_dc.map(&:qdmTitle), [
+        'Intervention, Order',
+        'Intervention, Performed'
+      ]
+
       assert_equal measure.source_data_criteria.map(&:qdmTitle), [
         'Encounter, Performed',
         'Procedure, Performed',
@@ -148,6 +155,7 @@ class CQLLoaderTest < Minitest::Test
         'Diagnosis',
         'Encounter, Performed',
         'Intervention, Order',
+        'Intervention, Performed',
         'Intervention, Performed',
         'Patient Characteristic Race',
         'Encounter, Performed',
@@ -169,8 +177,8 @@ class CQLLoaderTest < Minitest::Test
       assert_equal measure.source_data_criteria[0].hqmfOid, '2.16.840.1.113883.10.20.28.4.5'
 
       # Test direct reference code elements are filled with info from hitting vsac
-      assert_equal measure.source_data_criteria[22].description, 'Laboratory Test, Performed: UrineProteinTests'
-      assert_equal measure.source_data_criteria[22].codeListId, '2.16.840.1.113883.3.464.1003.109.12.1024'
+      assert_equal measure.source_data_criteria[23].description, 'Laboratory Test, Performed: UrineProteinTests'
+      assert_equal measure.source_data_criteria[23].codeListId, '2.16.840.1.113883.3.464.1003.109.12.1024'
       assert_equal measure.source_data_criteria[6].description, 'Diagnosis: KidneyFailure'
       assert_equal measure.source_data_criteria[6].codeListId, '2.16.840.1.113883.3.464.1003.109.12.1028'
     end


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
