### PR TITLE
Update version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec :development_group => :test
 
 gem 'mongoid', '~> 6.4.2'
 
-gem 'cqm-models', '~> 1.2.0'
+gem 'cqm-models', '~> 2.0.0'
 # gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
 # gem 'cqm-models', :path => '../cqm-models'
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ gemspec :development_group => :test
 
 gem 'mongoid', '~> 6.4.2'
 
-# gem 'cqm-models', '~> 1.0.2'
-gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
+gem 'cqm-models', '~> 1.2.0'
+# gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
 # gem 'cqm-models', :path => '../cqm-models'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,7 @@
-GIT
-  remote: https://github.com/projecttacoma/cqm-models.git
-  revision: b5cf44abcccffc51111438c4cf4d64830da9d9bb
-  branch: master
-  specs:
-    cqm-models (1.0.2)
-
 PATH
   remote: .
   specs:
-    cqm-parsers (1.0.0)
+    cqm-parsers (2.0.0)
       activesupport (~> 5.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)
@@ -54,6 +47,7 @@ GEM
       url
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    cqm-models (2.0.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.3.1)
@@ -62,7 +56,7 @@ GEM
       ffi (>= 1.3.0)
     factory_girl (4.1.0)
       activesupport (>= 3.0.0)
-    ffi (1.10.0)
+    ffi (1.11.1)
     hashdiff (0.3.8)
     highline (1.7.10)
     i18n (1.6.0)
@@ -70,8 +64,8 @@ GEM
     json (2.2.0)
     log4r (1.1.10)
     log_switch (1.0.0)
-    macaddr (1.7.1)
-      systemu (~> 2.6.2)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
     memoist (0.9.3)
     method_source (0.8.2)
     mini_portile2 (2.4.0)
@@ -114,7 +108,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
-    rubyzip (1.2.2)
+    rubyzip (1.2.3)
     safe_yaml (1.0.5)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -158,7 +152,7 @@ DEPENDENCIES
   byebug (~> 6.0.2)
   cane (~> 2.3.0)
   codecov
-  cqm-models!
+  cqm-models (~> 2.0.0)
   cqm-parsers!
   factory_girl (~> 4.1.0)
   minitest (~> 5.3)

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '1.1.0'
+  s.version = '2.0.0'
 
   s.add_dependency 'mustache'
   s.add_dependency 'erubis', '~> 2.7.0'

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '1.0.0'
+  s.version = '1.1.0'
 
   s.add_dependency 'mustache'
   s.add_dependency 'erubis', '~> 2.7.0'


### PR DESCRIPTION
Update version to 1.1.0, breaking model changes are in update
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

❗️BEFORE MERGE ❗️
- [ ] AFTER https://github.com/projecttacoma/cqm-models/pull/121 bundle install

**Submitter:**
- [x] This pull request describes why these changes were made.
