### PR TITLE
Fix issue with loading uploaded files from API

### DIFF
--- a/lib/measure-loader/mat_measure_files.rb
+++ b/lib/measure-loader/mat_measure_files.rb
@@ -53,7 +53,7 @@ module Measures
 
       def unzip_measure_zip_into_hash(zip_file)
         folders = Hash.new { |h, k| h[k] = {files: []} }
-        Zip::File.open zip_file do |file|
+        Zip::File.open zip_file.path do |file|
           file.each do |f|
             pn = Pathname(f.name)
             next if '__MACOSX'.in? pn.each_filename  # ignore anything in a __MACOSX folder


### PR DESCRIPTION
Simply adds `.path` on to the parameter passed into the the zip loader. This was done by bonnie_bundler. It normalizes out the slight differences of the test, multipart and normal uploaded files by just asking them for the `path` of the file.

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-2089 https://jira.mitre.org/browse/BONNIE-2094
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @hackrm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
