### PR TITLE
V0.2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    cqm-parsers (0.2.3)
+    cqm-parsers (0.2.4)
       activesupport (~> 4.2.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)
@@ -114,7 +114,7 @@ GEM
       mongoid (>= 4.0, < 6.0)
     mustache (1.1.0)
     netrc (0.11.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     origin (2.3.1)
     parallel (1.17.0)

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '0.2.3'
+  s.version = '0.2.4'
 
   s.add_dependency 'mustache'
   s.add_dependency 'rest-client', '~>2.0.1'

--- a/lib/qrda-export/catI-r5/qrda_templates/device_ordered.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/device_ordered.mustache
@@ -22,10 +22,10 @@
             </playingDevice>
           </participantRole>
         </participant>
-        {{#negationRationale}}
-        {{> qrda_templates/template_partials/_reason}}
-        {{/negationRationale}}
       </supply>
     </entryRelationship>
+    {{#negationRationale}}
+    {{> qrda_templates/template_partials/_reason}}
+    {{/negationRationale}}
   </act>
 </entry>

--- a/lib/qrda-export/catI-r5/qrda_templates/encounter_ordered.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/encounter_ordered.mustache
@@ -15,10 +15,10 @@
         {{#authorDatetime}}
         {{> qrda_templates/template_partials/_author}}
         {{/authorDatetime}}
-        {{#negationRationale}}
-        {{> qrda_templates/template_partials/_reason}}
-        {{/negationRationale}}
       </encounter>
     </entryRelationship>
+    {{#negationRationale}}
+    {{> qrda_templates/template_partials/_reason}}
+    {{/negationRationale}}
   </act>
 </entry>

--- a/lib/qrda-export/catI-r5/qrda_templates/medication_discharge.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/medication_discharge.mustache
@@ -46,10 +46,10 @@
         {{#authorDatetime}}
         {{> qrda_templates/template_partials/_author_participation}}
         {{/authorDatetime}}
-        {{#negationRationale}}
-        {{> qrda_templates/template_partials/_reason}}
-        {{/negationRationale}} 
       </substanceAdministration>
     </entryRelationship>
+    {{#negationRationale}}
+    {{> qrda_templates/template_partials/_reason}}
+    {{/negationRationale}} 
   </act>
 </entry>

--- a/lib/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
@@ -30,10 +30,10 @@
         {{#authorDatetime}}
         {{> qrda_templates/template_partials/_author}}
         {{/authorDatetime}}
-        {{#negationRationale}}
-        {{> qrda_templates/template_partials/_reason}}
-        {{/negationRationale}}
       </supply>
     </entryRelationship>
+    {{#negationRationale}}
+    {{> qrda_templates/template_partials/_reason}}
+    {{/negationRationale}}
   </act>
 </entry>

--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_medication_details.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_medication_details.mustache
@@ -6,6 +6,6 @@
 {{/negated}}
 {{^negated}}
 {{#dosage}}
-	<doseQuantity value="{{value}}" unit="{{unit}}"/>
+	<doseQuantity value="{{value_as_float}}" unit="{{unit}}"/>
 {{/dosage}}
 {{/negated}}

--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_medication_details.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_medication_details.mustache
@@ -6,6 +6,6 @@
 {{/negated}}
 {{^negated}}
 {{#dosage}}
-	<doseQuantity value="{{value_as_float}}" unit="{{unit}}"/>
+	<doseQuantity value="{{value_as_float}}"/>
 {{/dosage}}
 {{/negated}}

--- a/lib/qrda-export/helper/cat_1_view_helper.rb
+++ b/lib/qrda-export/helper/cat_1_view_helper.rb
@@ -123,6 +123,10 @@ module Qrda
           translation_list
         end
 
+        def value_as_float
+          self['value'].to_f
+        end
+
         def result_value
           return "<value xsi:type=\"CD\" nullFlavor=\"UNK\"/>" unless self['result']
           result_string = if self['result'].is_a? Array

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -48,7 +48,7 @@ module QRDA
         if @result_xpath
           entry.result = extract_result_values(entry_element)
         end
-        extract_reason_or_negation(entry_element, entry)
+        extract_negation(entry_element, entry)
         entry
       end
 
@@ -132,24 +132,28 @@ module QRDA
         end
       end
 
-      # extracts the reason or negation data. if an element is negated and the code has a null flavor, a random code is assigned for calculation
-      # coded_parent_element is the 'parent' element when the coded is nested (e.g., medication order)
-      def extract_reason_or_negation(parent_element, entry, coded_parent_element = nil)
-        coded_parent_element ||= parent_element
-        reason_element = parent_element.xpath(".//cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value | .//cda:entryRelationship[@typeCode='RSON']/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.1.27']/cda:code")
+      def extract_reason(parent_element)
+        return unless @reason_xpath
+        reason_element = parent_element.xpath(@reason_xpath)
         negation_indicator = parent_element['negationInd']
-        unless reason_element.blank?
-          if negation_indicator.eql?('true')
-            entry.negationRationale = code_if_present(reason_element.first)
-          else
-            entry.reason = code_if_present(reason_element.first) unless @entry_does_not_have_reason
-          end
-        end
-        extract_negated_code(coded_parent_element, entry)
+        # Return and do not set reason attribute if the entry is negated
+        return nil if negation_indicator.eql?('true')
+        
+        reason_element.blank? ? nil : code_if_present(reason_element.first) 
       end
 
-      def extract_negated_code(coded_parent_element, entry)
-        code_elements = coded_parent_element.xpath(@code_xpath)
+      def extract_negation(parent_element, entry)
+        negation_element = parent_element.xpath("./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value")
+        negation_indicator = parent_element['negationInd']
+        # Return and do not set negationRationale attribute if the entry is not negated
+        return unless negation_indicator.eql?('true') 
+        
+        entry.negationRationale = code_if_present(negation_element.first) unless negation_element.blank?
+        extract_negated_code(parent_element, entry)
+      end
+
+      def extract_negated_code(parent_element, entry)
+        code_elements = parent_element.xpath(@code_xpath)
         code_elements.each do |code_element|
           if code_element['nullFlavor'] == 'NA' && code_element['sdtc:valueSet']
             entry.dataElementCodes = [{ code: code_element['sdtc:valueSet'], codeSystem: 'NA_VALUESET' }]

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -125,8 +125,8 @@ module QRDA
         return unless value_element && !value_element['nullFlavor']
         value = value_element['value']
         if value.present?
-          return value.strip.to_i if (value_element['unit'] == "1" || value_element['unit'].nil?)
-          return QDM::Quantity.new(value.strip.to_i, value_element['unit'])
+          return value.strip.to_f if (value_element['unit'] == "1" || value_element['unit'].nil?)
+          return QDM::Quantity.new(value.strip.to_f, value_element['unit'])
         elsif value_element['code'].present?
           return code_if_present(value_element)
         end
@@ -160,7 +160,7 @@ module QRDA
       def extract_scalar(parent_element, scalar_xpath)
         scalar_element = parent_element.at_xpath(scalar_xpath)
         return unless scalar_element
-        QDM::Quantity.new(scalar_element['value'].to_i, scalar_element['unit'])
+        QDM::Quantity.new(scalar_element['value'].to_f, scalar_element['unit'])
       end
 
       def extract_components(parent_element)

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -93,13 +93,13 @@ module QRDA
           high_time = DateTime.parse(parent_element.at_xpath(interval_xpath)['value'])
         end
         if parent_element.at_xpath("#{interval_xpath}/cda:low")
-          low_time = DateTime.parse(parent_element.at_xpath("#{interval_xpath}/cda:low")['value'])
+          low_time = if parent_element.at_xpath("#{interval_xpath}/cda:low")['value']
+                       DateTime.parse(parent_element.at_xpath("#{interval_xpath}/cda:low")['value'])
+                     end
         end
         if parent_element.at_xpath("#{interval_xpath}/cda:high")
           high_time = if parent_element.at_xpath("#{interval_xpath}/cda:high")['value']
                         DateTime.parse(parent_element.at_xpath("#{interval_xpath}/cda:high")['value'])
-                      else
-                        DateTime.new(9999,1,1)
                       end
         end
         if parent_element.at_xpath("#{interval_xpath}/cda:center")

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -38,8 +38,11 @@ module QRDA
 
       def create_entry(entry_element, _nrh = NarrativeReferenceHandler.new)
         entry = @entry_class.new
-        @entry_id_map[extract_id(entry_element, @id_xpath).value] ||= []
-        @entry_id_map[extract_id(entry_element, @id_xpath).value] << entry.id
+        entry_qrda_id = extract_id(entry_element, @id_xpath)
+        # Create a hash to map all of entry.ids to the same QRDA ids. This will be used to merge QRDA entries
+        # that represent the same event. 
+        @entry_id_map["#{entry_qrda_id.value}_#{entry_qrda_id.namingSystem}"] ||= []
+        @entry_id_map["#{entry_qrda_id.value}_#{entry_qrda_id.namingSystem}"] << entry.id
         entry.dataElementCodes = extract_codes(entry_element, @code_xpath)
         extract_dates(entry_element, entry)
         if @result_xpath
@@ -55,7 +58,7 @@ module QRDA
         id_element = parent_element.at_xpath(id_xpath)
         return unless id_element
         # If an extension is not included, use the root as the value.  Other wise use the extension
-        value = id_element['extension'] ? id_element['extension'] : id_element['root']
+        value = id_element['extension'] || id_element['root']
         identifier = QDM::Id.new(value: value, namingSystem: id_element['root'])
         identifier
       end

--- a/lib/qrda-import/data-element-importers/assessment_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/assessment_performed_importer.rb
@@ -9,6 +9,7 @@ module QRDA
         @result_xpath = "./cda:value"
         @method_xpath = './cda:methodCode'
         @components_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.149']"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::AssessmentPerformed
       end
 
@@ -16,6 +17,7 @@ module QRDA
         assessment_performed = super
         assessment_performed.method = code_if_present(entry_element.at_xpath(@method_xpath))
         assessment_performed.components = extract_components(entry_element)
+        assessment_performed.reason = extract_reason(entry_element)
         assessment_performed
       end
 

--- a/lib/qrda-import/data-element-importers/device_applied_importer.rb
+++ b/lib/qrda-import/data-element-importers/device_applied_importer.rb
@@ -9,6 +9,7 @@ module QRDA
         @relevant_period_xpath = "./cda:effectiveTime"
         @anatomical_location_site_xpath = "./cda:targetSiteCode"
         @anatomical_approach_site_xpath = "./cda:approachSiteCode"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::DeviceApplied
       end
 
@@ -16,6 +17,7 @@ module QRDA
         device_applied = super
         device_applied.anatomicalLocationSite = code_if_present(entry_element.at_xpath(@anatomical_location_site_xpath))
         device_applied.anatomicalApproachSite = code_if_present(entry_element.at_xpath(@anatomical_approach_site_xpath))
+        device_applied.reason = extract_reason(entry_element)
         device_applied
       end
 

--- a/lib/qrda-import/data-element-importers/device_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/device_order_importer.rb
@@ -6,11 +6,13 @@ module QRDA
         @id_xpath = './cda:entryRelationship/cda:supply/cda:id'
         @code_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.9']/cda:participant/cda:participantRole/cda:playingDevice/cda:code"
         @author_datetime_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.9']/cda:author/cda:time"
+        @reason_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.9']/cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::DeviceOrder
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         device_order = super
+        device_order.reason = extract_reason(entry_element)
         device_order
       end
 

--- a/lib/qrda-import/data-element-importers/diagnostic_study_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/diagnostic_study_order_importer.rb
@@ -7,12 +7,14 @@ module QRDA
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @method_xpath = './cda:methodCode'
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::DiagnosticStudyOrder
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         diagnostic_study_order = super
         diagnostic_study_order.method = code_if_present(entry_element.at_xpath(@method_xpath))
+        diagnostic_study_order.reason = extract_reason(entry_element)
         diagnostic_study_order
       end
 

--- a/lib/qrda-import/data-element-importers/diagnostic_study_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/diagnostic_study_performed_importer.rb
@@ -13,6 +13,7 @@ module QRDA
         @method_xpath = './cda:methodCode'
         @facility_location_xpath = "./cda:participant[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.100']/cda:participantRole[@classCode='SDLOC']/cda:code"
         @components_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.149']"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::DiagnosticStudyPerformed
       end
 
@@ -23,6 +24,7 @@ module QRDA
         diagnostic_study_performed.method = code_if_present(entry_element.at_xpath(@method_xpath))
         diagnostic_study_performed.facilityLocation = code_if_present(entry_element.at_xpath(@facility_location_xpath))
         diagnostic_study_performed.components = extract_components(entry_element)
+        diagnostic_study_performed.reason = extract_reason(entry_element)
         diagnostic_study_performed
       end
 

--- a/lib/qrda-import/data-element-importers/encounter_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/encounter_order_importer.rb
@@ -7,12 +7,14 @@ module QRDA
         @code_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']/cda:code"
         @author_datetime_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']/cda:author/cda:time"
         @facility_location_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']/cda:participant[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.100']/cda:participantRole[@classCode='SDLOC']/cda:code"
+        @reason_xpath = "./cda:entryRelationship/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']/cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::EncounterOrder
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         encounter_order = super
         encounter_order.facilityLocation = code_if_present(entry_element.at_xpath(@facility_location_xpath))
+        encounter_order.reason = extract_reason(entry_element)
         encounter_order
       end
 

--- a/lib/qrda-import/data-element-importers/immunization_administered_importer.rb
+++ b/lib/qrda-import/data-element-importers/immunization_administered_importer.rb
@@ -5,11 +5,13 @@ module QRDA
         super(entry_finder)
         @relevant_period_xpath = nil
         @author_datetime_xpath = "./cda:effectiveTime"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::ImmunizationAdministered
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         immunization_administered = super
+        immunization_administered.reason = extract_reason(entry_element)
         immunization_administered
       end
 

--- a/lib/qrda-import/data-element-importers/intervention_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/intervention_order_importer.rb
@@ -6,11 +6,13 @@ module QRDA
         @id_xpath = './cda:id'
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::InterventionOrder
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         intervention_order = super
+        intervention_order.reason = extract_reason(entry_element)
         intervention_order
       end
 

--- a/lib/qrda-import/data-element-importers/intervention_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/intervention_performed_importer.rb
@@ -9,12 +9,14 @@ module QRDA
         @author_datetime_xpath = "./cda:author/cda:time"
         @result_xpath = "./cda:entryRelationship[@typeCode='REFR']/cda:observation/cda:value"
         @status_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.93']/cda:value"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::InterventionPerformed
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         intervention_performed = super
         intervention_performed.status = code_if_present(entry_element.at_xpath(@status_xpath))
+        intervention_performed.reason = extract_reason(entry_element)
         intervention_performed
       end
 

--- a/lib/qrda-import/data-element-importers/laboratory_test_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/laboratory_test_order_importer.rb
@@ -7,12 +7,14 @@ module QRDA
         @code_xpath = './cda:code'
         @author_datetime_xpath = "./cda:author/cda:time"
         @method_xpath = './cda:methodCode'
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::LaboratoryTestOrder
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         laboratory_test_order = super
         laboratory_test_order.method = code_if_present(entry_element.at_xpath(@method_xpath))
+        laboratory_test_order.reason = extract_reason(entry_element)
         laboratory_test_order
       end
 

--- a/lib/qrda-import/data-element-importers/laboratory_test_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/laboratory_test_performed_importer.rb
@@ -12,6 +12,7 @@ module QRDA
         @result_xpath = "./cda:entryRelationship[@typeCode='REFR']/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.2']/cda:value"
         @result_datetime_xpath = "./cda:entryRelationship[@typeCode='REFR']/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.2']/cda:effectiveTime"
         @components_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.149']"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::LaboratoryTestPerformed
       end
 
@@ -21,6 +22,7 @@ module QRDA
         laboratory_test_performed.method = code_if_present(entry_element.at_xpath(@method_xpath))
         laboratory_test_performed.resultDatetime = extract_time(entry_element, @result_datetime_xpath)
         laboratory_test_performed.components = extract_components(entry_element)
+        laboratory_test_performed.reason = extract_reason(entry_element)
         laboratory_test_performed
       end
 

--- a/lib/qrda-import/data-element-importers/medication_administered_importer.rb
+++ b/lib/qrda-import/data-element-importers/medication_administered_importer.rb
@@ -4,11 +4,13 @@ module QRDA
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']"))
         super(entry_finder)
         @route_xpath = "./cda:routeCode"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::MedicationAdministered
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         medication_administered = super
+        medication_administered.reason = extract_reason(entry_element)
         medication_administered
       end
 

--- a/lib/qrda-import/data-element-importers/medication_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/medication_order_importer.rb
@@ -3,11 +3,13 @@ module QRDA
     class MedicationOrderImporter < MedicationImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']"))
         super(entry_finder)
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::MedicationOrder
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         medication_order = super
+        medication_order.reason = extract_reason(entry_element)
         medication_order
       end
 

--- a/lib/qrda-import/data-element-importers/physical_exam_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/physical_exam_performed_importer.rb
@@ -11,6 +11,7 @@ module QRDA
         @result_xpath = "./cda:value"
         @anatomical_location_site_xpath = "./cda:targetSiteCode"
         @components_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.149']"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::PhysicalExamPerformed
       end
 
@@ -19,6 +20,7 @@ module QRDA
         physical_exam_performed.method = code_if_present(entry_element.at_xpath(@method_xpath))
         physical_exam_performed.anatomicalLocationSite = code_if_present(entry_element.at_xpath(@anatomical_location_site_xpath))
         physical_exam_performed.components = extract_components(entry_element)
+        physical_exam_performed.reason = extract_reason(entry_element)
         physical_exam_performed
       end
 

--- a/lib/qrda-import/data-element-importers/procedure_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/procedure_order_importer.rb
@@ -10,6 +10,7 @@ module QRDA
         @anatomical_approach_site_xpath = "./cda:approachSiteCode"
         @anatomical_location_site_xpath = "./cda:targetSiteCode"
         @ordinality_xpath = "./cda:priorityCode"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::ProcedureOrder
       end
 
@@ -19,6 +20,7 @@ module QRDA
         procedure_order.anatomicalApproachSite = code_if_present(entry_element.at_xpath(@anatomical_approach_site_xpath))
         procedure_order.anatomicalLocationSite = code_if_present(entry_element.at_xpath(@anatomical_location_site_xpath))
         procedure_order.ordinality = code_if_present(entry_element.at_xpath(@ordinality_xpath))
+        procedure_order.reason = extract_reason(entry_element)
         procedure_order
       end
 

--- a/lib/qrda-import/data-element-importers/procedure_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/procedure_performed_importer.rb
@@ -15,6 +15,7 @@ module QRDA
         @ordinality_xpath = "./cda:priorityCode"
         @incision_datetime_xpath = "./cda:entryRelationship/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.89']/cda:effectiveTime"
         @components_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.149']"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::ProcedurePerformed
       end
 
@@ -27,6 +28,7 @@ module QRDA
         procedure_performed.ordinality = code_if_present(entry_element.at_xpath(@ordinality_xpath))
         procedure_performed.incisionDatetime = extract_time(entry_element, @incision_datetime_xpath)
         procedure_performed.components = extract_components(entry_element)
+        procedure_performed.reason = extract_reason(entry_element)
         procedure_performed
       end
 

--- a/lib/qrda-import/data-element-importers/substance_administered_importer.rb
+++ b/lib/qrda-import/data-element-importers/substance_administered_importer.rb
@@ -1,9 +1,9 @@
 module QRDA
   module Cat1
-    class SubstanceAdministeredImporter < MedicationAdministeredImporter
+    class SubstanceAdministeredImporter < MedicationImporter
       def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']"))
         super(entry_finder)
-        @entry_does_not_have_reason = true
+        @route_xpath = "./cda:routeCode"
         @entry_class = QDM::SubstanceAdministered
       end
 

--- a/lib/qrda-import/patient_importer.rb
+++ b/lib/qrda-import/patient_importer.rb
@@ -92,7 +92,7 @@ module QRDA
           next unless data_element.respond_to?(:relatedTo) && data_element.relatedTo
           relations_to_add = []
           data_element.relatedTo.each do |related_to|
-            relations_to_add << entry_id_map[related_to.value]
+            relations_to_add << entry_id_map["#{related_to.value}_#{related_to.namingSystem}"]
           end
           data_element.relatedTo.destroy
           relations_to_add.each do |relation_to_add|

--- a/test/fixtures/qrda/single_entry.xml
+++ b/test/fixtures/qrda/single_entry.xml
@@ -279,133 +279,69 @@
   </observation>            
 </entry>
 <entry>
-  <act classCode="ACT" moodCode="EVN" >
-    <!--Encounter performed Act -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.133" extension="2017-08-01"/>
-    <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
-    <entryRelationship typeCode="SUBJ">
-      <encounter classCode="ENC" moodCode="EVN">
-        <!--  Encounter activities template -->
-        <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01"/> 
-        <!-- Encounter performed template -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.23" extension="2017-08-01"/>
-        <id root="1.3.6.1.4.1.115" extension="5ada27b7aeac50e2db23159e"/>
-        <code code="99203" codeSystem="2.16.840.1.113883.6.12" sdtc:valueSet="2.16.840.1.113883.3.600.1916"><originalText>Encounter, Performed: Office Visit</originalText><translation code="99203" codeSystem="2.16.840.1.113883.6.12"/>
-</code>
-        <text>Encounter, Performed: Office Visit</text>
-        <statusCode code="completed"/>
-        <effectiveTime>
-          <!-- We try to look for the admit/discharge times on the encounter if they are
-               there. If not, we fall back to the typical start/end date. -->
-          <low value='20120709080000'/>
-          <high value='20120709081500'/>
-        </effectiveTime>
-      </encounter>
-    </entryRelationship>
-    
-  </act>
-</entry>
-
-<entry>
-  <act classCode="ACT" moodCode="EVN" >
-    <!--Encounter performed Act -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.133" extension="2017-08-01"/>
-    <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
-    <entryRelationship typeCode="SUBJ">
-      <encounter classCode="ENC" moodCode="EVN">
-        <!--  Encounter activities template -->
-        <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01"/> 
-        <!-- Encounter performed template -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.23" extension="2017-08-01"/>
-        <id root="1.3.6.1.4.1.115" extension="5ada27b7aeac50e2db23159e"/>
-        <code code="99213" codeSystem="2.16.840.1.113883.6.12" sdtc:valueSet="2.16.840.1.113883.3.600.1916"><originalText>Encounter, Performed: Office Visit</originalText><translation code="99213" codeSystem="2.16.840.1.113883.6.12"/>
-</code>
-        <text>Encounter, Performed: Office Visit</text>
-        <statusCode code="completed"/>
-        <effectiveTime>
-          <!-- We try to look for the admit/discharge times on the encounter if they are
-               there. If not, we fall back to the typical start/end date. -->
-          <low value='20120911080000'/>
-          <high value='20120911083000'/>
-        </effectiveTime>
-      </encounter>
-    </entryRelationship>
-    
-  </act>
-</entry>
-
-
-
-<entry>
-  <act classCode="ACT" moodCode="EVN">
-    <!--Encounter performed Act -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.133" extension="2017-08-01"/>
-    <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
-    <entryRelationship typeCode="SUBJ">
-      <encounter classCode="ENC" moodCode="EVN">
-        <!--  Encounter activities template -->
-        <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01"/>
-        <!-- Encounter performed template -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.23" extension="2017-08-01"/>
-        <id root="1.3.6.1.4.1.115" extension="5ada27b7aeac50e2db23159f"/>
-        <code code="99243" codeSystem="2.16.840.1.113883.6.12" sdtc:valueSet="2.16.840.1.113883.3.600.1916">
-          <originalText>Encounter, Performed: Office Visit</originalText>
-          <translation code="99243" codeSystem="2.16.840.1.113883.6.12"/>
-        </code>
-        <text>Encounter, Performed: Office Visit</text>
-        <statusCode code="completed"/>
-        <effectiveTime>
-          <!-- We try to look for the admit/discharge times on the encounter if they are
-               there. If not, we fall back to the typical start/end date. -->
-          <low value='20120911080000'/>
-          <high value='20120911083000'/>
-        </effectiveTime>
-      </encounter>
-    </entryRelationship>
-
-  </act>
-</entry>
-
-<entry>
-  <act classCode="ACT" moodCode="EVN">
-    <!--Encounter performed Act -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.133" extension="2017-08-01"/>
-    <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
-    <entryRelationship typeCode="SUBJ">
-      <encounter classCode="ENC" moodCode="EVN">
-        <!--  Encounter activities template -->
-        <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01"/>
-        <!-- Encounter performed template -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.23" extension="2017-08-01"/>
-        <id root="1.3.6.1.4.1.116" extension="5ada27b7aeac50e2db23159f"/>
-        <code code="99243" codeSystem="2.16.840.1.113883.6.12" sdtc:valueSet="2.16.840.1.113883.3.600.1916">
-          <originalText>Encounter, Performed: Office Visit</originalText>
-          <translation code="99243" codeSystem="2.16.840.1.113883.6.12"/>
-        </code>
-        <text>Encounter, Performed: Office Visit</text>
-        <statusCode code="completed"/>
-        <effectiveTime>
-          <!-- We try to look for the admit/discharge times on the encounter if they are
-               there. If not, we fall back to the typical start/end date. -->
-          <low value='20120912080000'/>
-          <high value='20120912083000'/>
-        </effectiveTime>
-      </encounter>
-    </entryRelationship>
-
-  </act>
-</entry>
-
-
-
-
-
-
-
-
-
-
-
+              <observation classCode="OBS" moodCode="EVN" >
+                <!-- Laboratory Test Performed (V4) -->
+                <templateId root="2.16.840.1.113883.10.20.24.3.38" extension="2017-08-01"/>
+                <id root="1.3.6.1.4.1.115" extension="5caccea1c1c3885c063275b5"/>
+                  <code code="1234" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+                <text></text>
+                <statusCode code="completed"/>
+                  <!-- QDM Attribute: Relevant Period -->
+                  <effectiveTime><low nullFlavor='UNK'/><high value='20190101000000'/></effectiveTime>
+                  <!-- QDM Attribute: Method -->
+                  <methodCode code="1234" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>                  <!-- QDM Attribute: Author dateTime -->
+                  <author>
+                    <templateId root="2.16.840.1.113883.10.20.24.3.155" extension="2017-08-01"/>
+                    <time value='20190101000000'/>
+                    <assignedAuthor>
+                          <id nullFlavor="NA"/>
+                    </assignedAuthor>
+                  </author>                  <!-- QDM Attribute: Reason -->
+                  <entryRelationship typeCode="RSON">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.24.3.88" extension="2014-12-01"/>
+                      <id root="1.3.6.1.4.1.115" extension="4776ca40-3d16-0137-8d03-2cde48001122" />
+                      <code code="77301-0" codeSystem="2.16.840.1.113883.6.1" displayName="reason" codeSystemName="LOINC"/>
+                      <statusCode code="completed"/>
+                      <effectiveTime><low value='20180101000000'/><high value='20190101000000'/></effectiveTime>
+                      <value code="1234" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" xsi:type="CD"/>
+                    </observation>
+                  </entryRelationship>                  <!-- QDM Attribute: Result -->
+                  <entryRelationship typeCode="REFR">
+                   <observation classCode="OBS" moodCode="EVN">
+                      <!-- Conforms to C-CDA R2 Result Observation (V2) -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01"/>
+                      <!-- Result (QRDA I R3) -->
+                      <templateId root="2.16.840.1.113883.10.20.24.3.87" extension="2016-02-01"/>
+                      <id root="1.3.6.1.4.1.115" extension="4776ed20-3d16-0137-8d03-2cde48001122"/>
+                        <code code="1234" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+                      <statusCode code="completed"/>
+                      <effectiveTime value='20190101000000'/>
+                      <value xsi:type="PQ" value="3.4"/>
+                   </observation>
+                  </entryRelationship>
+                  
+                  <!-- QDM Attribute: Status -->
+                  <entryRelationship typeCode="REFR">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.24.3.93"/>
+                      <id root="1.3.6.1.4.1.115" extension="47770da0-3d16-0137-8d03-2cde48001122"/>
+                      <code code="33999-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Status"/>
+                      <value xsi:type="CD" code="1234" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+                    </observation>
+                  </entryRelationship>                  <!-- QDM Attribute: Components -->
+                  <entryRelationship typeCode="REFR">
+                       <observation classCode="OBS" moodCode="EVN">
+                          <!-- Component -->
+                          <templateId root="2.16.840.1.113883.10.20.24.3.149" extension="2017-08-01" />
+                          <id root="47771d40-3d16-0137-8d03-2cde48001122"/>
+                            <!--  QDM Attribute: Code -->
+                            <code code="1234" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+                          <!--  QDM Attribute: Result -->
+                          <value xsi:type="CD" code="1234" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+                      </observation>
+                  </entryRelationship>                </observation>
+            </entry>
         </section>
       </component>
 

--- a/test/unit/qrda/patient_importer_test.rb
+++ b/test/unit/qrda/patient_importer_test.rb
@@ -10,16 +10,60 @@ module QRDA
         @map = {}
       end
 
+      # Test that duplicate entries are combined using ids
       def test_patient_dedup
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/0_1 N_GP Adult 2.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
         @importer.import_data_elements(@patient, doc, @map)
         
-        assert_equal 2, @patient.dataElements.length
+        # There are 4 entry elements in the uploaded QRDA file
+        # 2 entries are combined since the share the same id (root and extension)
+        # 1 entry has a common root (1.3.6.1.4.1.115), and a unique extension (5ada27b7aeac50e2db23159f)
+        # 1 entry has a common extension (5ada27b7aeac50e2db23159f), and a unique root (1.3.6.1.4.1.116)
+        assert_equal 3, @patient.dataElements.length
         de = @patient.dataElements.first
         assert_equal 2, de.dataElementCodes.length
         assert_operator de.dataElementCodes[0], :!=, de.dataElementCodes[1]
+      end
+
+      # Test that a low value can be null flavored
+      def test_low_time_import
+        patient1 = QDM::Patient.new
+        doc = Nokogiri::XML(File.read('test/fixtures/qrda/single_entry.xml'))
+        doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+        doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+        @importer.import_data_elements(patient1, doc, @map)
+
+        assert_equal 1, patient1.dataElements.length
+        de = patient1.dataElements.first
+        # Low value is nullFlavored
+        assert_equal nil, de.relevantPeriod.low
+
+        low = doc.at_css('templateId[root="2.16.840.1.113883.10.20.24.3.38"] ~ effectiveTime low')
+        # Remove nullFavor
+        low.attributes['nullFlavor'].remove
+        # Add time value
+        low.set_attribute('value', '20120709081500')
+        patient2 = QDM::Patient.new
+        @importer.import_data_elements(patient2, doc, @map)
+
+        assert_equal 1, patient2.dataElements.length
+        de = patient2.dataElements.first
+        assert_equal 2012, de.relevantPeriod.low.year
+      end
+
+      # Test that result values are imported with decimal precision
+      def test_result_value_import
+        patient1 = QDM::Patient.new
+        doc = Nokogiri::XML(File.read('test/fixtures/qrda/single_entry.xml'))
+        doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+        doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+        @importer.import_data_elements(patient1, doc, @map)
+
+        assert_equal 1, patient1.dataElements.length
+        de = patient1.dataElements.first
+        assert_equal 3.4, de.result
       end
     end
   end


### PR DESCRIPTION
This pull request updates the old 0.2.3 with changes that have already been included in cqm-reports for QRDA Cat 1 R5 import and export.  The 0.2.x versions are currently in use in Cypress v4.

PR does 4 things
1) use value and naming system when finding unique QRDA entries
2) Allow for low and high times to be nullFlavored
3) Quantities can have decimals
4) medications in eCQM are always precoordinated, do not export unit

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-515
https://jira.mitre.org/browse/CYPRESS-580
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code