### PR TITLE
V3 rails5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :development_group => :test
 
-gem 'mongoid', '~> 5.0.0'
+gem 'mongoid', '~> 6.4.2'
 
 # gem 'cqm-models', '~> 3.0.0'
 # gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -9,16 +9,16 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '3.0.0.0'
+  s.version = '3.1.0.0'
 
   s.add_dependency 'cqm-models', '~> 3.0.0'
   s.add_dependency 'mustache'
   s.add_dependency 'erubis', '~> 2.7.0'
-  s.add_dependency 'mongoid', '~> 5.0.0'
-  s.add_dependency 'mongoid-tree', '~> 2.0.0'
-  s.add_dependency 'activesupport', '~> 4.2.0'
+  s.add_dependency 'mongoid', '~> 6.4'
+  s.add_dependency 'mongoid-tree', '~> 2.1'
+  s.add_dependency 'activesupport', '~> 5.0'
 
-  s.add_dependency 'protected_attributes', '~> 1.0.5'
+  s.add_dependency 'protected_attributes_continued', '~> 1.4.0'
   s.add_dependency 'uuid', '~> 2.3.7'
   s.add_dependency 'builder', '~> 3.1'
   s.add_dependency 'nokogiri', '>= 1.8.5', '< 1.11.0'


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
