### PR TITLE
Ensure Users Can Only Upload FHIR Measures Bundles

### DIFF
--- a/lib/measure-loader/mat_measure_files.rb
+++ b/lib/measure-loader/mat_measure_files.rb
@@ -35,8 +35,6 @@ module Measures
       measure_assets = measure_folder[0][:files] # make_measure_artifacts(parse_measure_files(measure_folder))
 
       return measure_assets
-    rescue StandardError => e
-      raise MeasureLoadingInvalidPackageException.new("Error processing package file: #{e.message}")
     end
 
     def self.valid_zip?(zip_file)
@@ -81,6 +79,8 @@ module Measures
         end
 
         folders
+      rescue
+        raise MeasureLoadingInvalidPackageException.new("The uploaded file is not a zip file.")
       end
 
       def make_measure_artifacts(measure_files)

--- a/lib/util/bundle_utils.rb
+++ b/lib/util/bundle_utils.rb
@@ -2,10 +2,10 @@ module FHIR
   class BundleUtils
     def self.get_measure_bundle(measure_files)
       measure_bundle = measure_files.select {|file| file[:basename].to_s == 'measure-json-bundle.json'}
-      raise MeasureLoadingInvalidPackageException.new("No measure bundle found") if measure_bundle.empty?
-      raise MeasureLoadingInvalidPackageException.new("Multiple measure bundles found") if measure_bundle.length > 1
+      raise Measures::MeasureLoadingInvalidPackageException.new("The uploaded measure bundle does not contain the proper FHIR JSON file.") if measure_bundle.empty?
+      raise Measures::MeasureLoadingInvalidPackageException.new("Multiple measure bundles were found.") if measure_bundle.length > 1
       bundle_resource = JSON.parse measure_bundle[0][:contents]
-      raise MeasureLoadingInvalidPackageException.new("Invalid Measure bundle") unless bundle_resource['resourceType'] == 'Bundle'
+      raise Measures::MeasureLoadingInvalidPackageException.new("The uploaded files do not appear to be in the correct format.") unless bundle_resource['resourceType'] == 'Bundle'
 
       bundle_resource
     end


### PR DESCRIPTION
## Jira Ticket

https://jira.cms.gov/browse/MAT-1175

## Changes

- Remove exception from `create_from_zip_file`
- Add more specific exception to `unzip_measure_zip_into_hash`
- Fix and update exceptions in `get_measure_bundle`

## Associated Changes

- [Pull request in `bonnie`](https://github.com/projecttacoma/bonnie/pull/1471) 

---

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
