### PR TITLE
MAT-1536 display CQL & Valueset for selected measure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git
-  revision: 544a1365f41d5b48a04743d114f9a95209083583
+  revision: df5a9ee3630090ff903e1e25414f5006e8a7cec1
   branch: develop
   specs:
     fhir-mongoid-models (0.0.1)
@@ -47,13 +47,13 @@ GEM
     byebug (6.0.2)
     cane (2.3.0)
       parallel
-    codecov (0.2.3)
+    codecov (0.2.5)
       colorize
       json
       simplecov
     coderay (1.1.3)
     colorize (0.8.1)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.3.2)

--- a/lib/measure-loader/bundle_loader.rb
+++ b/lib/measure-loader/bundle_loader.rb
@@ -99,7 +99,8 @@ module Measures
       cqm_measure = CQM::Measure.new(fhir_measure: fhir_measure,
                                      libraries: libraries,
                                      cms_id: cms_id,
-                                     title: fhir_measure.title.value)
+                                     title: fhir_measure.title.value,
+                                     description: fhir_measure.description.value)
 
       cqm_measure.cql_libraries = parse_cql_elm(libraries, fhir_measure.name.value, fhir_measure.version.value)
       elms = cqm_measure.cql_libraries.map(&:elm)

--- a/lib/measure-loader/value_set_helpers.rb
+++ b/lib/measure-loader/value_set_helpers.rb
@@ -48,7 +48,13 @@ module Measures
             cache_key = [code_hash, '']
             if vs_model_cache[cache_key].nil?
               vs_compose = prepare_value_set_compose(code_reference, code_system_def)
-              vs_model_cache[cache_key] = FHIR::ValueSet.new(compose: vs_compose, fhirId: code_hash)
+              vs_model_cache[cache_key] = FHIR::ValueSet.new(
+                name: FHIR::PrimitiveString.transform_json(code_reference['name'], nil ),
+                title: FHIR::PrimitiveString.transform_json(code_reference['display'], nil),
+                version: FHIR::PrimitiveString.new(value: ''),
+                compose: vs_compose,
+                fhirId: code_hash
+              )
             end
             value_sets_from_single_code_references << vs_model_cache[cache_key]
           end

--- a/lib/measure-loader/vsac_value_set_loader.rb
+++ b/lib/measure-loader/vsac_value_set_loader.rb
@@ -78,6 +78,7 @@ module Measures
       FHIR::ValueSet.new(
         fhirId: vs_element['ID'],
         url: FHIR::PrimitiveString.transform_json("#{VS_URL_PRIFIX} #{vs_element['ID']}", nil),
+        title: FHIR::PrimitiveString.transform_json(vs_element["displayName"], nil),
         name: FHIR::PrimitiveString.transform_json(vs_element["displayName"], nil),
         version: FHIR::PrimitiveString.transform_json(
           vs_element["version"] == "N/A" ? query_version : vs_element["version"], nil

--- a/test/unit/measure-loader/bundle_loader_test.rb
+++ b/test/unit/measure-loader/bundle_loader_test.rb
@@ -20,6 +20,7 @@ class BundleLoaderTest < Minitest::Test
       measure = loader.extract_measure
 
       assert_equal 'CMS104', measure.fhir_measure.title.value
+      assert_equal 'CMS104v8', measure.cms_id
       assert_equal '42BF391F-38A3-4C0F-9ECE-DCD47E9609D9', measure.set_id, 'Measure set Id does not match expected value.'
       assert_equal 5, measure.libraries.size, 'Mismatching library size.'
       # Not sure whether this association was a hmbt at one point or if this was never passing, but

--- a/test/unit/measure-loader/value_set_loader_test.rb
+++ b/test/unit/measure-loader/value_set_loader_test.rb
@@ -37,10 +37,12 @@ class VSACValueSetLoaderTest < Minitest::Test
       value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
       loader = Measures::BundleLoader.new(@measure_file_base, @empty_measure_details, value_set_loader)
       measure = loader.extract_measure
-      value_set = measure.value_sets.select { |vs| vs.fhirId == '2.16.840.1.113883.3.117.1.7.1.93'}
-      assert_equal 1, value_set.length
-      assert_equal 21, value_set[0].compose.include[0].concept.length
-      assert_equal 'Patient Refusal', value_set[0].name.value
+      value_sets = measure.value_sets.select { |vs| vs.fhirId == '2.16.840.1.113883.3.117.1.7.1.93'}
+      assert_equal 'Patient Refusal', value_sets.first.title.value
+      assert_equal 'Patient Refusal', value_sets.first.name.value
+      assert_equal 1, value_sets.length
+      assert_equal 21, value_sets[0].compose.include[0].concept.length
+      assert_equal 'Patient Refusal', value_sets[0].name.value
       assert_equal 46, measure.value_sets.length
     end
   end


### PR DESCRIPTION
MAT-1536 Display Measure Details on Measure Dashboard

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
