### PR TITLE
Follow Measure Resource's Library reference when partial or full URL

### DIFF
--- a/lib/measure-loader/bundle_loader.rb
+++ b/lib/measure-loader/bundle_loader.rb
@@ -268,7 +268,7 @@ module Measures
     end
 
     def get_measure_lib_name_version(fhir_measure_lib, libraries)
-      main_measure_lib = libraries.find { |lib| lib.url.value == fhir_measure_lib || lib.url.value.include?(fhir_measure_lib) }
+      main_measure_lib = libraries.find { |lib| lib.url.value.include?(fhir_measure_lib) }
       return main_measure_lib.name.value, main_measure_lib.version.value
     end
 

--- a/lib/measure-loader/bundle_loader.rb
+++ b/lib/measure-loader/bundle_loader.rb
@@ -268,7 +268,7 @@ module Measures
     end
 
     def get_measure_lib_name_version(fhir_measure_lib, libraries)
-      main_measure_lib = libraries.find { |lib| lib.url.value == fhir_measure_lib}
+      main_measure_lib = libraries.find { |lib| lib.url.value == fhir_measure_lib || lib.url.value.include?(fhir_measure_lib) }
       return main_measure_lib.name.value, main_measure_lib.version.value
     end
 


### PR DESCRIPTION
Follow Measure resource's Library ref when a partial or full URL.

Depending on which iteration of the MAT is used to package a measure, the Measure resource will either use a partial or full URL to identify the Library containing the measure logic. For UAT round 1, it is possible that both iterations of the MAT will be available to users.

Current production MAT packages Measure Resource's with partial URL Library references.
```
"library": [
          "Library/8a788f25739040ca01739045420b0012"
        ]
```
Future production MAT will use full URLs:
```
"library": [
          "http://ecqi.healthit.gov/ecqms/Library/CreateFhirProportionMeasure1597691499140"
        ]
```

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
