### PR TITLE
MAT-1634 Displaying measure details(CQL & ValueSets) fails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git
-  revision: df5a9ee3630090ff903e1e25414f5006e8a7cec1
+  revision: 12733d3de840b2f2811f488a07578a672745b8e0
   branch: develop
   specs:
     fhir-mongoid-models (0.0.1)

--- a/lib/measure-loader/bundle_loader.rb
+++ b/lib/measure-loader/bundle_loader.rb
@@ -115,7 +115,7 @@ module Measures
       # TODO: uncomment once we have TS models integrated in bonnie.
       # cqm_measure.source_data_criteria = libraries.map{|lib| lib.create_data_elements(cqm_measure.value_sets.compact)}.flatten
 
-      cqm_measure.population_sets = parse_population_sets(fhir_measure)
+      cqm_measure.population_sets = parse_population_sets(fhir_measure, measure_lib_name)
 
       cqm_measure.set_id = guid_identifier.upcase
       cqm_measure
@@ -180,7 +180,7 @@ module Measures
       cms_identifier.present? ? "CMS#{cms_identifier['value']}#{resource_version}" : resource_version
     end
 
-    def parse_population_sets(fhir_measure)
+    def parse_population_sets(fhir_measure, measure_lib_name)
       scoring_type = fhir_measure.scoring.coding.first.code.value
 
       fhir_measure.group.map.with_index do |group, index|
@@ -193,7 +193,7 @@ module Measures
 
         group.population.each do |pop|
           stmt_ref = CQM::StatementReference.new(
-            library_name: fhir_measure.name.value,
+            library_name: measure_lib_name,
             statement_name: pop.criteria.expression.value
           )
           case pop.code.coding.first.code.value
@@ -218,7 +218,7 @@ module Measures
               observation_function: stmt_ref,
               aggregation_type: get_observation_population_aggregation_type(pop),
               observation_parameter: CQM::StatementReference.new(
-                library_name: fhir_measure.name.value,
+                library_name: measure_lib_name,
                 statement_name: get_observation_population_parameter(pop)
               )
             )
@@ -229,7 +229,7 @@ module Measures
             title: "PopSet#{index+1} Stratification #{i+1}",
             stratification_id: "#{population_set.population_set_id}_Stratification_#{i+1}",
             statement: CQM::StatementReference.new(
-              library_name: fhir_measure.name.value,
+              library_name: measure_lib_name,
               statement_name: stratum.criteria.expression.value
             )
           )


### PR DESCRIPTION
MAT-1634 Displaying measure details(CQL & ValueSets) fails

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
