### PR TITLE
[MAT-1641] Updating pop set parsing to use extracted lib name instead of measure name

### DIFF
--- a/test/unit/measure-loader/bundle_loader_test.rb
+++ b/test/unit/measure-loader/bundle_loader_test.rb
@@ -27,6 +27,7 @@ class BundleLoaderTest < Minitest::Test
       # value_set_ids doesn't come with the embeds_many :value_sets relation.
       # assert_equal 46, measure.value_set_ids.count, 'Mismatching number of value set Ids.'
       assert_equal 5, measure.cql_libraries.size, 'Mismatching number of cql libraries.'
+      assert_equal 'DischargedonAntithromboticTherapy', measure.main_cql_library, "Did not correctly determine the main measure library name."
 
       # TODO: uncomment once we have TS models integrated in bonnie.
       # assert_equal 10, measure.source_data_criteria.length, 'Mismatching number of source_data_criteria.'


### PR DESCRIPTION
Updating population set, observation, and stratification parsing to use the extracted measure_lib_name instead of expecting the measure name to match the measure library name. This is another edit to enable BoF to support the current and updated MAT FHIR packaged.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: [MAT-1641](https://jira.cms.gov/browse/MAT-1641)
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
