### PR TITLE
[MAT-1685] Checking episode of care argument 

### DIFF
--- a/lib/measure-loader/bundle_loader.rb
+++ b/lib/measure-loader/bundle_loader.rb
@@ -117,6 +117,8 @@ module Measures
 
       cqm_measure.population_sets = parse_population_sets(fhir_measure, measure_lib_name)
 
+      cqm_measure.calculation_method = 'EPISODE_OF_CARE' if @measure_details[:episode_of_care]
+
       cqm_measure.set_id = guid_identifier.upcase
       cqm_measure
     end

--- a/test/unit/measure-loader/bundle_loader_test.rb
+++ b/test/unit/measure-loader/bundle_loader_test.rb
@@ -22,6 +22,7 @@ class BundleLoaderTest < Minitest::Test
       assert_equal 'CMS104', measure.fhir_measure.title.value
       assert_equal "CMS104v8", measure.cms_id, 'Mismatching cms_id.'
       assert_equal '42BF391F-38A3-4C0F-9ECE-DCD47E9609D9', measure.set_id, 'Measure set Id does not match expected value.'
+      assert_equal 'PATIENT', measure.calculation_method, "Did not correctly determine the main measure library name."
       assert_equal 5, measure.libraries.size, 'Mismatching library size.'
       # Not sure whether this association was a hmbt at one point or if this was never passing, but
       # value_set_ids doesn't come with the embeds_many :value_sets relation.
@@ -33,6 +34,17 @@ class BundleLoaderTest < Minitest::Test
       # assert_equal 10, measure.source_data_criteria.length, 'Mismatching number of source_data_criteria.'
       # assert_equal [CQM::DataElement], measure.source_data_criteria.map(&:class).uniq, 'Mismatching source_data_criteria object type.'
     end
+  end
+
+  def test_episode_care_option
+    setup
+    @measure_details = { 'episode_of_care'=> true }
+
+    measure_file = File.new File.join(@fixtures_path, 'CMS104_v6_0_fhir_Artifacts.zip')
+    loader = Measures::BundleLoader.new(measure_file, @measure_details)
+    measure = loader.extract_measure
+
+    assert_equal'EPISODE_OF_CARE', measure.calculation_method
   end
 
   def test_parse_elm

--- a/test/unit/measure-loader/bundle_loader_test.rb
+++ b/test/unit/measure-loader/bundle_loader_test.rb
@@ -44,7 +44,7 @@ class BundleLoaderTest < Minitest::Test
     loader = Measures::BundleLoader.new(measure_file, @measure_details)
     measure = loader.extract_measure
 
-    assert_equal'EPISODE_OF_CARE', measure.calculation_method
+    assert_equal 'EPISODE_OF_CARE', measure.calculation_method
   end
 
   def test_parse_elm


### PR DESCRIPTION
Overriding the default PATIENT calculation type to EPISODE_OF_CARE when the passed in episode_of_care option is set to true.

When `CQM::Measure.calculation_method` is set to `EPISODE_OF_CARE`, the uploaded measure's details page will display relavent text (box highlighting mine): 

![Screen Shot 2020-08-26 at 6 17 25 AM](https://user-images.githubusercontent.com/56264529/91292061-fd8ee380-e763-11ea-9e33-a51e3576d072.png)


**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: [MAT-1685](https://jira.cms.gov/browse/MAT-1685)
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
