### PR TITLE
MAT-1711 Stop Storing Binary Files in Mongo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'mongoid', '~> 7.1'
 
 # gem 'cqm-models', '~> 3.0.0'
 # gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
-gem 'fhir-mongoid-models', git: 'https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git', branch: 'feature/MAT-1711'
+gem 'fhir-mongoid-models', git: 'https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git', branch: 'develop'
 
 group :development, :test do
   gem 'bundler-audit'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'mongoid', '~> 7.1'
 
 # gem 'cqm-models', '~> 3.0.0'
 # gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
-gem 'fhir-mongoid-models', git: 'https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git', branch: 'develop'
+gem 'fhir-mongoid-models', git: 'https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git', branch: 'feature/MAT-1711'
 
 group :development, :test do
   gem 'bundler-audit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git
-  revision: df5a9ee3630090ff903e1e25414f5006e8a7cec1
-  branch: develop
+  revision: 14b3559a8cf52cd583be887c6118c1ce6234769b
+  branch: feature/MAT-1711
   specs:
-    fhir-mongoid-models (0.0.1)
+    fhir-mongoid-models (0.0.2)
 
 PATH
   remote: .

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git
-  revision: 14b3559a8cf52cd583be887c6118c1ce6234769b
-  branch: feature/MAT-1711
+  revision: 8e665e78f82e3af76904adf2ea297b35565f900f
+  branch: develop
   specs:
     fhir-mongoid-models (0.0.2)
 

--- a/lib/measure-loader/bundle_loader.rb
+++ b/lib/measure-loader/bundle_loader.rb
@@ -15,9 +15,7 @@ module Measures
     def extract_measure
       measure_files = MATMeasureFiles.create_from_zip_file(@measure_zip)
       measure_bundle = FHIR::BundleUtils.get_measure_bundle(measure_files)
-      measure = create_measure(measure_bundle)
-      measure.package = CQM::MeasurePackage.new(file: BSON::Binary.new(@measure_zip.read))
-      measure
+      create_measure(measure_bundle)
     end
 
     def self.update_population_set_and_strat_titles(measure, population_titles)


### PR DESCRIPTION
MAT-1711 Stop Storing Binary Files in Mongo
- updated parsing

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
