### PR TITLE
[MAT-1757] Replacing VSAC Username/Password with API Key in VSAC Calls

### DIFF
--- a/lib/measure-loader/vsac_value_set_loader.rb
+++ b/lib/measure-loader/vsac_value_set_loader.rb
@@ -7,8 +7,7 @@ module Measures
       options.symbolize_keys!
       @vsac_options = options[:options]
       @vsac_ticket_granting_ticket = options[:ticket_granting_ticket]
-      @vsac_username = options[:username]
-      @vsac_password = options[:password]
+      @vsac_api_key = options[:api_key]
       @vs_model_cache = {}
     end
 
@@ -48,7 +47,7 @@ module Measures
 
     def load_api
       return @api if @api.present?
-      @api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], ticket_granting_ticket: @vsac_ticket_granting_ticket, username: @vsac_username, password: @vsac_password)
+      @api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], ticket_granting_ticket: @vsac_ticket_granting_ticket, api_key: @vsac_api_key)
       return @api
     end
 

--- a/lib/util/vsac_api.rb
+++ b/lib/util/vsac_api.rb
@@ -7,7 +7,7 @@ module Util
     class VSACError < StandardError
     end
 
-    # Error represnting a not found response from the API. Includes OID for reporting to user.
+    # Error representing a not found response from the API. Includes OID for reporting to user.
     class VSNotFoundError < VSACError
       attr_reader :oid
       def initialize(oid)
@@ -23,7 +23,7 @@ module Util
       end
     end
 
-    # Error represnting a program not found response from the API.
+    # Error representing a program not found response from the API.
     class VSACProgramNotFoundError < VSACError
       attr_reader :oid
       def initialize(program)
@@ -31,7 +31,7 @@ module Util
       end
     end
 
-    # Error represnting a response from the API that had no concepts.
+    # Error representing a response from the API that had no concepts.
     class VSEmptyError < VSACError
       attr_reader :oid
       def initialize(oid)
@@ -50,14 +50,14 @@ module Util
     # Raised when the user credentials were invalid.
     class VSACInvalidCredentialsError < VSACError
       def initialize
-        super('VSAC ULMS credentials are invalid.')
+        super('VSAC UMLS credentials are invalid.')
       end
     end
 
     # Raised when a call requiring auth is attempted when no ticket_granting_ticket or credentials were provided.
     class VSACNoCredentialsError < VSACError
       def initialize
-        super('VSAC ULMS credentials were not provided.')
+        super('VSAC UMLS credentials were not provided.')
       end
     end
 
@@ -93,7 +93,7 @@ module Util
         end
 
         # if a ticket_granting_ticket was passed in, check it and raise errors if found
-        # username and password will be ignored
+        # VSAC API Key will be ignored
         if !options[:ticket_granting_ticket].nil?
           provided_ticket_granting_ticket = options[:ticket_granting_ticket]
           if provided_ticket_granting_ticket[:ticket].nil? || provided_ticket_granting_ticket[:expires].nil?
@@ -105,9 +105,9 @@ module Util
           @ticket_granting_ticket = { ticket: provided_ticket_granting_ticket[:ticket],
                                       expires: provided_ticket_granting_ticket[:expires] }
 
-        # if username and password were provided use them to get a ticket granting ticket
-        elsif !options[:username].nil? && !options[:password].nil?
-          @ticket_granting_ticket = get_ticket_granting_ticket(options[:username], options[:password])
+          # if api key was provided use it to get a ticket granting ticket
+        elsif !options[:api_key].nil?
+          @ticket_granting_ticket = get_ticket_granting_ticket(options[:api_key])
         end
       end
 
@@ -304,13 +304,13 @@ module Util
                                      params: { service: TICKET_SERVICE_PARAM})
       end
 
-      # Use your username and password to retrive a ticket granting ticket from VSAC
-      def get_ticket_granting_ticket(username, password)
+      # Use your API Key to retrive a ticket granting ticket from VSAC
+      def get_ticket_granting_ticket(api_key)
         response = Typhoeus.post(
-          "#{@config[:auth_url]}/Ticket",
-          # looks like typheous sometimes switches the order of username/password when encoding
-          # which vsac cant handle (!?), so encode first
-          body: URI.encode_www_form(username: username, password: password)
+            "#{@config[:auth_url]}/Ticket",
+            # looks like typheous sometimes switches the order of username/password when encoding
+            # which vsac cant handle (!?), so encode first
+            body: URI.encode_www_form(apikey: api_key)
         )
         raise VSACInvalidCredentialsError.new if response.response_code == 401
         validate_http_status(response.response_code)

--- a/lib/util/vsac_api.rb
+++ b/lib/util/vsac_api.rb
@@ -307,10 +307,8 @@ module Util
       # Use your API Key to retrive a ticket granting ticket from VSAC
       def get_ticket_granting_ticket(api_key)
         response = Typhoeus.post(
-            "#{@config[:auth_url]}/Ticket",
-            # looks like typheous sometimes switches the order of username/password when encoding
-            # which vsac cant handle (!?), so encode first
-            body: URI.encode_www_form(apikey: api_key)
+          "#{@config[:auth_url]}/Ticket",
+          body: URI.encode_www_form(apikey: api_key)
         )
         raise VSACInvalidCredentialsError.new if response.response_code == 401
         validate_http_status(response.response_code)

--- a/test/fixtures/vcr_cassettes/measure__definition_with_same_name_as_a_library_definition.yml
+++ b/test/fixtures/vcr_cassettes/measure__definition_with_same_name_as_a_library_definition.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__direct_reference_code_handles_creation_of_codeListId_hash1.yml
+++ b/test/fixtures/vcr_cassettes/measure__direct_reference_code_handles_creation_of_codeListId_hash1.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__direct_reference_code_handles_creation_of_codeListId_hash2.yml
+++ b/test/fixtures/vcr_cassettes/measure__direct_reference_code_handles_creation_of_codeListId_hash2.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__invalid_composite_measure_with_missing_component_measure.yml
+++ b/test/fixtures/vcr_cassettes/measure__invalid_composite_measure_with_missing_component_measure.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__invalid_composite_measure_with_missing_composite_measure_files.yml
+++ b/test/fixtures/vcr_cassettes/measure__invalid_composite_measure_with_missing_composite_measure_files.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__load_composite_measure.yml
+++ b/test/fixtures/vcr_cassettes/measure__load_composite_measure.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__measure_including_draft.yml
+++ b/test/fixtures/vcr_cassettes/measure__measure_including_draft.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__negated_source_criteria_with_drc.yml
+++ b/test/fixtures/vcr_cassettes/measure__negated_source_criteria_with_drc.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__population_titles.yml
+++ b/test/fixtures/vcr_cassettes/measure__population_titles.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__source_data_criteria_creation.yml
+++ b/test/fixtures/vcr_cassettes/measure__source_data_criteria_creation.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__stratifications_and_observations.yml
+++ b/test/fixtures/vcr_cassettes/measure__stratifications_and_observations.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__test_5_4_CQL_measure.yml
+++ b/test/fixtures/vcr_cassettes/measure__test_5_4_CQL_measure.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__test_can_use_cache.yml
+++ b/test/fixtures/vcr_cassettes/measure__test_can_use_cache.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__test_cms_id.yml
+++ b/test/fixtures/vcr_cassettes/measure__test_cms_id.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__test_invalid_composite_measure_with_component_measure_missing_xml_file.yml
+++ b/test/fixtures/vcr_cassettes/measure__test_invalid_composite_measure_with_component_measure_missing_xml_file.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__test_measure.yml
+++ b/test/fixtures/vcr_cassettes/measure__test_measure.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__test_multiple_libraries.yml
+++ b/test/fixtures/vcr_cassettes/measure__test_multiple_libraries.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__test_proportional_cv_measure.yml
+++ b/test/fixtures/vcr_cassettes/measure__test_proportional_cv_measure.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__test_ratio_cv_measure.yml
+++ b/test/fixtures/vcr_cassettes/measure__test_ratio_cv_measure.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/measure__unique_characters_stored_correctly.yml
+++ b/test/fixtures/vcr_cassettes/measure__unique_characters_stored_correctly.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_draft_no_profile_version.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_draft_no_profile_version.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_draft_profile.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_draft_profile.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_draft_verion.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_draft_verion.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_empty_concept_list.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_empty_concept_list.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_meausre_defined_no_backup_profile.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_meausre_defined_no_backup_profile.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_no_profile_version.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_no_profile_version.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_not_found_response.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_not_found_response.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_profile.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_profile.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_release.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_release.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_version.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_version.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vs_loading_with_username_password.yml
+++ b/test/fixtures/vcr_cassettes/vs_loading_with_username_password.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vsac_auth_bad_credentials.yml
+++ b/test/fixtures/vcr_cassettes/vsac_auth_bad_credentials.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=baduser&password=badpass
+      string: apikey=badkey
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vsac_auth_good_credentials.yml
+++ b/test/fixtures/vcr_cassettes/vsac_auth_good_credentials.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vsac_auth_good_credentials_and_simple_call.yml
+++ b/test/fixtures/vcr_cassettes/vsac_auth_good_credentials_and_simple_call.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vsac_vs_include_draft_no_profile.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_include_draft_no_profile.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vsac_vs_include_draft_with_profile.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_include_draft_with_profile.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vsac_vs_no_options.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_no_options.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vsac_vs_not_found.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_not_found.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vsac_vs_release.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_release.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/fixtures/vcr_cassettes/vsac_vs_version.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_version.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     body:
       encoding: US-ASCII
-      string: username=<VSAC_USERNAME>&password=<VSAC_PASSWORD>
+      string: apikey=<VSAC_API_KEY>
     headers:
       User-Agent:
       - Typhoeus - https://github.com/typhoeus/typhoeus

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -114,6 +114,6 @@ APP_CONFIG = {'vsac'=> {'auth_url'=> 'https://vsac.nlm.nih.gov/vsac/ws',
                         'default_profile' => 'MU2 Update 2016-04-01'}}
 
 def get_ticket_granting_ticket_using_env_vars
-  api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: ENV['VSAC_USERNAME'], password: ENV['VSAC_PASSWORD'])
+  api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
   return api.ticket_granting_ticket
 end

--- a/test/unit/measure-loader/value_set_loader_test.rb
+++ b/test/unit/measure-loader/value_set_loader_test.rb
@@ -94,10 +94,10 @@ class VSACValueSetLoaderTest < Minitest::Test
     end
   end
 
-  def test_loading_with_username_password
+  def test_loading_with_api_key
     VCR.use_cassette('vs_loading_with_username_password', @vcr_options) do
       vsac_options = { release: 'eCQM Update 2018 EP-EC and EH' }
-      value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, username: ENV['VSAC_USERNAME'], password: ENV['VSAC_PASSWORD'])
+      value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, api_key: ENV['VSAC_API_KEY'])
       loader = Measures::CqlLoader.new(@measure_file_base, @empty_measure_details, value_set_loader)
       measure = loader.extract_measures[0]
       assert_equal 162, measure.value_sets.select { |vs| vs.oid == "2.16.840.1.113883.3.600.1.1834"}[0].concepts.size

--- a/test/unit/vsac/vsac_api_auth_test.rb
+++ b/test/unit/vsac/vsac_api_auth_test.rb
@@ -7,43 +7,25 @@ class VSACAPIAuthTest < Minitest::Test
 
   def test_valid_username_and_password_provided_does_not_raise
     VCR.use_cassette("vsac_auth_good_credentials") do
-      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: ENV['VSAC_USERNAME'], password: ENV['VSAC_PASSWORD'])
+      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
       assert api.ticket_granting_ticket
       assert api.ticket_granting_ticket[:ticket]
       assert api.ticket_granting_ticket[:expires]
     end
   end
 
-  def test_invalid_username_and_password_provided
+  def test_invalid_api_key_provided
     VCR.use_cassette("vsac_auth_bad_credentials") do
       assert_raises Util::VSAC::VSACInvalidCredentialsError do
-        api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: 'baduser', password: 'badpass')
+        api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: 'badkey')
         assert api
       end
     end
   end
 
-  def test_empty_username_and_password_provided
+  def test_empty_api_key_provided
     api = nil
-    api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: nil, password: nil)
-
-    assert_raises Util::VSAC::VSACNoCredentialsError do
-      api.get_valueset('2.16.840.1.113762.1.4.1')
-    end
-  end
-
-  def test_provided_username_but_no_password
-    api = nil
-    api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: "vsacuser")
-
-    assert_raises Util::VSAC::VSACNoCredentialsError do
-      api.get_valueset('2.16.840.1.113762.1.4.1')
-    end
-  end
-
-  def test_provided_password_but_no_username
-    api = nil
-    api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: "vsacuser")
+    api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: nil)
 
     assert_raises Util::VSAC::VSACNoCredentialsError do
       api.get_valueset('2.16.840.1.113762.1.4.1')
@@ -52,9 +34,7 @@ class VSACAPIAuthTest < Minitest::Test
 
   def test_valid_ticket_granting_ticket_provided_and_used
     VCR.use_cassette("vsac_auth_good_credentials_and_simple_call") do
-      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'],
-                                    username: ENV['VSAC_USERNAME'],
-                                    password: ENV['VSAC_PASSWORD'])
+      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
       assert api.ticket_granting_ticket
 
       reused_ticket_granting_ticket = {

--- a/test/unit/vsac/vsac_api_test.rb
+++ b/test/unit/vsac/vsac_api_test.rb
@@ -18,7 +18,7 @@ class VSACApiTest < Minitest::Test
 
   def test_get_valueset_with_version
     VCR.use_cassette("vsac_vs_version") do
-      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: ENV['VSAC_USERNAME'], password: ENV['VSAC_PASSWORD'])
+      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
       vs = api.get_valueset("2.16.840.1.113883.3.600.1.1834", version: "MU2 EP Update 2014-07-01")
       assert vs
       doc = Nokogiri::XML(vs)
@@ -28,7 +28,7 @@ class VSACApiTest < Minitest::Test
 
   def test_get_valuest_with_include_draft_no_profile
     VCR.use_cassette("vsac_vs_include_draft_no_profile") do
-      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: ENV['VSAC_USERNAME'], password: ENV['VSAC_PASSWORD'])
+      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
       assert_raises Util::VSAC::VSACArgumentError do
         api.get_valueset("2.16.840.1.113883.3.600.1.1834", include_draft: true)
       end
@@ -37,7 +37,7 @@ class VSACApiTest < Minitest::Test
 
   def test_get_valueset_with_include_draft_specified_profile
     VCR.use_cassette("vsac_vs_include_draft_with_profile") do
-      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: ENV['VSAC_USERNAME'], password: ENV['VSAC_PASSWORD'])
+      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
       vs = api.get_valueset("2.16.840.1.113762.1.4.1", include_draft: true, profile: "eCQM Update 2018-05-04")
       assert vs
       doc = Nokogiri::XML(vs)
@@ -47,7 +47,7 @@ class VSACApiTest < Minitest::Test
 
   def test_get_valueset_no_options
     VCR.use_cassette("vsac_vs_no_options") do
-      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: ENV['VSAC_USERNAME'], password: ENV['VSAC_PASSWORD'])
+      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
       vs = api.get_valueset("2.16.840.1.113762.1.4.1")
       assert vs
       doc = Nokogiri::XML(vs)
@@ -57,7 +57,7 @@ class VSACApiTest < Minitest::Test
 
   def test_get_valueset_not_found
     VCR.use_cassette("vsac_vs_not_found") do
-      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: ENV['VSAC_USERNAME'], password: ENV['VSAC_PASSWORD'])
+      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
       assert_raises Util::VSAC::VSNotFoundError do
         api.get_valueset("bad.oid")
       end
@@ -66,7 +66,7 @@ class VSACApiTest < Minitest::Test
 
   def test_get_valueset_with_release
     VCR.use_cassette("vsac_vs_release") do
-      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], username: ENV['VSAC_USERNAME'], password: ENV['VSAC_PASSWORD'])
+      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
       vs = api.get_valueset("2.16.840.1.113762.1.4.1", release: "MU2 EP Update 2014-05-30")
       assert vs
       doc = Nokogiri::XML(vs)

--- a/test/vcr_setup.rb
+++ b/test/vcr_setup.rb
@@ -9,14 +9,12 @@ VCR.configure do |c|
   c.hook_into :webmock
 
   # To avoid storing plain text VSAC credentials or requiring the VSAC credentials
-  # be provided at every run of the rake tests, provide the VSAC_USERNAME and VSAC_PASSWORD
+  # be provided at every run of the rake tests, provide the VSAC_API_KEY
   # whenever you need to record a cassette that requires valid credentials
-  ENV['VSAC_USERNAME'] = "vcrtest" unless ENV['VSAC_USERNAME']
-  ENV['VSAC_PASSWORD'] = "vcrpass" unless ENV['VSAC_PASSWORD']
+  ENV['VSAC_API_KEY'] = "vcrpass" unless ENV['VSAC_API_KEY']
 
   # Ensure plain text passwords do not show up during logging
-  c.filter_sensitive_data('<VSAC_USERNAME>') {ENV['VSAC_USERNAME']}
-  c.filter_sensitive_data('<VSAC_PASSWORD>') {URI.escape(ENV['VSAC_PASSWORD'])}
+  c.filter_sensitive_data('<VSAC_API_KEY>') {URI.escape(ENV['VSAC_API_KEY'])}
   c.default_cassette_options = { record: :once }
 
   # Add a custom matcher for use with the bulk request by typheous, so we can ignore service ticket


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
