### PR TITLE
[MAT-1759] VSAC Value Set Loader using API Key

### DIFF
--- a/lib/measure-loader/vsac_value_set_loader.rb
+++ b/lib/measure-loader/vsac_value_set_loader.rb
@@ -8,8 +8,7 @@ module Measures
       options.symbolize_keys!
       @vsac_options = options[:options]
       @vsac_ticket_granting_ticket = options[:ticket_granting_ticket]
-      @vsac_username = options[:username]
-      @vsac_password = options[:password]
+      @vsac_api_key = options[:api_key]
       @vs_model_cache = {}
     end
 
@@ -50,7 +49,7 @@ module Measures
 
     def load_api
       return @api if @api.present?
-      @api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], ticket_granting_ticket: @vsac_ticket_granting_ticket, username: @vsac_username, password: @vsac_password)
+      @api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], ticket_granting_ticket: @vsac_ticket_granting_ticket, api_key: @vsac_api_key)
       return @api
     end
 


### PR DESCRIPTION
Missed updating the VS Loader utility (mostly for  currently skipped tests) to use the vsac api key.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
