### PR TITLE
MAT-2263 measurement period is not initialized correctly in bonnie

### DIFF
--- a/lib/measure-loader/bundle_loader.rb
+++ b/lib/measure-loader/bundle_loader.rb
@@ -121,6 +121,7 @@ module Measures
       cqm_measure.calculate_sdes = @measure_details[:calculate_sdes] unless @measure_details[:calculate_sdes].nil?
 
       cqm_measure.set_id = guid_identifier.upcase
+      cqm_measure.measure_period = FHIR::BundleUtils.get_measurement_period(fhir_measure)
       cqm_measure
     end
 

--- a/lib/util/bundle_utils.rb
+++ b/lib/util/bundle_utils.rb
@@ -18,5 +18,17 @@ module FHIR
       resources
     end
 
+    def self.get_measurement_period(fhir_measure)
+      mp = {}
+      if fhir_measure.effectivePeriod
+        mp[:start] = fhir_measure.effectivePeriod.start&.value
+        mp[:end] = fhir_measure.effectivePeriod.end&.value
+      else
+        # Default measurement period
+        mp[:start] = '2020-01-01'
+        mp[:end] = '2020-12-31'
+      end
+      mp
+    end
   end
 end

--- a/lib/util/bundle_utils.rb
+++ b/lib/util/bundle_utils.rb
@@ -25,8 +25,8 @@ module FHIR
         mp[:end] = fhir_measure.effectivePeriod.end&.value
       else
         # Default measurement period
-        mp[:start] = '2020-01-01'
-        mp[:end] = '2020-12-31'
+        mp[:start] = '2019-01-01'
+        mp[:end] = '2019-12-31'
       end
       mp
     end

--- a/test/unit/measure-loader/bundle_loader_test.rb
+++ b/test/unit/measure-loader/bundle_loader_test.rb
@@ -23,6 +23,8 @@ class BundleLoaderTest < Minitest::Test
       assert_equal "CMS104v8", measure.cms_id, 'Mismatching cms_id.'
       assert_equal '42BF391F-38A3-4C0F-9ECE-DCD47E9609D9', measure.set_id, 'Measure set Id does not match expected value.'
       assert_equal 'PATIENT', measure.calculation_method, "Did not correctly determine the main measure library name."
+      assert_equal '2021-01-01', measure.measure_period[:start], "Measurement period start date mismatch"
+      assert_equal '2021-12-31', measure.measure_period[:end], "Measurement period end date mismatch"
       assert_equal 5, measure.libraries.size, 'Mismatching library size.'
       # Not sure whether this association was a hmbt at one point or if this was never passing, but
       # value_set_ids doesn't come with the embeds_many :value_sets relation.


### PR DESCRIPTION
MAT-2263 measurement period is not initialized correctly in bonnie

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
