### PR TITLE
[MAT-2264] Add time component to Measurement Period

### DIFF
--- a/lib/util/bundle_utils.rb
+++ b/lib/util/bundle_utils.rb
@@ -21,12 +21,12 @@ module FHIR
     def self.get_measurement_period(fhir_measure)
       mp = {}
       if fhir_measure.effectivePeriod
-        mp[:start] = fhir_measure.effectivePeriod.start&.value
-        mp[:end] = fhir_measure.effectivePeriod.end&.value
+        mp[:start] = fhir_measure.effectivePeriod.start&.value << "T00:00:00"
+        mp[:end] = fhir_measure.effectivePeriod.end&.value << "T23:59:59"
       else
         # Default measurement period
-        mp[:start] = '2019-01-01'
-        mp[:end] = '2019-12-31'
+        mp[:start] = '2019-01-01T00:00:00'
+        mp[:end] = '2019-12-31T23:59:59'
       end
       mp
     end


### PR DESCRIPTION
Adding time component when parsing measurement period from effective period.

- Bonnie saves patient data with seconds precision.
- Start date will have zeroed out time.
- End date will have 23:59:59.


Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
