### PR TITLE
[MAT-2492] Replace Safe Nav with Hash.dig

### DIFF
--- a/lib/measure-loader/source_data_criteria_loader.rb
+++ b/lib/measure-loader/source_data_criteria_loader.rb
@@ -46,7 +46,8 @@ module Measures
     def extract_fields_from_single_code_reference_data_criteria(criteria)
       single_code_reference = criteria.at_css('value[codeSystem][code]') || criteria.at_css('code[codeSystem][code]')
       system_id = "#{single_code_reference['codeSystem']}_#{single_code_reference['codeSystemVersion']}".to_sym
-      concept = @single_code_concepts[system_id]&[single_code_reference['code'].to_sym] || get_concept_from_participation(criteria.at_css('participation'))
+      # concept = @single_code_concepts[system_id]&[single_code_reference['code'].to_sym] || get_concept_from_participation(criteria.at_css('participation'))
+      concept = @single_code_concepts&.dig(system_id, single_code_reference['code']&.to_sym) || get_concept_from_participation(criteria.at_css('participation'))
       value_set = concept._parent
       return {
         description: concept.display_name,


### PR DESCRIPTION
Replacing the safe nav with dig since Bonnie didn't like the safe nav syntax and dig is better designed for nested hashes.

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
