### PR TITLE
MAT-2680 JSON file name has changed in measure bundle

### DIFF
--- a/lib/util/bundle_utils.rb
+++ b/lib/util/bundle_utils.rb
@@ -1,7 +1,7 @@
 module FHIR
   class BundleUtils
     def self.get_measure_bundle(measure_files)
-      measure_bundle = measure_files.select {|file| file[:basename].to_s == 'measure-json-bundle.json'}
+      measure_bundle = measure_files.select {|file| file[:basename].to_s.end_with?('json')}
       raise Measures::MeasureLoadingInvalidPackageException.new("The uploaded measure bundle does not contain the proper FHIR JSON file.") if measure_bundle.empty?
       raise Measures::MeasureLoadingInvalidPackageException.new("Multiple measure bundles were found.") if measure_bundle.length > 1
 

--- a/test/unit/measure-loader/value_set_loader_test.rb
+++ b/test/unit/measure-loader/value_set_loader_test.rb
@@ -20,10 +20,10 @@ class VSACValueSetLoaderTest < Minitest::Test
       vs_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
       needed_value_sets = [{oid: "2.16.840.1.113883.3.117.1.7.1.292", version: nil, profile: nil}]
 
-      valuesets = vs_loader.retrieve_and_modelize_value_sets_from_vsac(needed_value_sets)
+      valuesets = vs_loader.retrieve_and_modelize_value_sets_from_vsac(needed_value_sets, {})
 
       stub_request(:any, /\./).to_timeout # disable all network connections
-      valuesets_again = vs_loader.retrieve_and_modelize_value_sets_from_vsac(needed_value_sets)
+      valuesets_again = vs_loader.retrieve_and_modelize_value_sets_from_vsac(needed_value_sets, {})
       WebMock.reset!
 
       assert_equal valuesets, valuesets_again


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
