### PR TITLE
MAT-2122 Dosage widget binding

### DIFF
--- a/lib/measure-loader/value_set_helpers.rb
+++ b/lib/measure-loader/value_set_helpers.rb
@@ -172,7 +172,8 @@ module Measures
             'EventTiming' => 'http://hl7.org/fhir/event-timing',
             'v3.TimingEvent' => 'http://terminology.hl7.org/CodeSystem/v3-TimingEvent',
             'TimingEvent' => 'http://terminology.hl7.org/CodeSystem/v3-TimingEvent',
-            'DaysOfWeek' => 'http://hl7.org/fhir/days-of-week'
+            'DaysOfWeek' => 'http://hl7.org/fhir/days-of-week',
+            'DoseAndRateType' => 'http://terminology.hl7.org/CodeSystem/dose-rate-type'
         }
       end
     end


### PR DESCRIPTION
MAT-2122 Dosage widget codesystem

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
