### PR TITLE
MAT-2555 update parsers to use mongoid models v0.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'mongoid', '~> 7.1'
 
 # gem 'cqm-models', '~> 3.0.0'
 # gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
-gem 'fhir-mongoid-models', git: 'https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git', branch: 'develop'
+gem 'fhir-mongoid-models', '~> 0.0.4'
 
 group :development, :test do
   gem 'bundler-audit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/MeasureAuthoringTool/fhir-mongoid-models.git
-  revision: 2cd067d9c0c772cde557dbdc3e9ef5e6b36eda51
-  branch: develop
-  specs:
-    fhir-mongoid-models (0.0.3)
-
 PATH
   remote: .
   specs:
@@ -63,6 +56,7 @@ GEM
     factory_girl (4.1.0)
       activesupport (>= 3.0.0)
     ffi (1.13.1)
+    fhir-mongoid-models (0.0.4)
     hashdiff (1.0.1)
     highline (1.7.10)
     i18n (1.8.5)
@@ -156,7 +150,7 @@ DEPENDENCIES
   codecov
   cqm-parsers!
   factory_girl (~> 4.1.0)
-  fhir-mongoid-models!
+  fhir-mongoid-models (~> 0.0.4)
   minitest (~> 5.3)
   minitest-reporters
   mongoid (~> 7.1)

--- a/test/unit/measure-loader/value_set_helpers_test.rb
+++ b/test/unit/measure-loader/value_set_helpers_test.rb
@@ -15,8 +15,8 @@ class ValueSetHelpersTest < Minitest::Test
     assert code_systems != nil
     assert_equal 87, code_systems['by_name'].keys.size
     assert_equal 87, code_systems['by_name'].values.size
-    assert_equal 79, code_systems['by_oid'].keys.size
-    assert_equal 79, code_systems['by_oid'].values.size
+    assert_equal 81, code_systems['by_oid'].keys.size
+    assert_equal 81, code_systems['by_oid'].values.size
     assert_equal 'http://snomed.info/sct', code_systems['by_oid']['2.16.840.1.113883.6.96']
     assert_nil code_systems['by_oid']['WRONG_OID']
     assert_equal 'http://snomed.info/sct', code_systems['by_name']['SNOMEDCT']

--- a/test/vcr_setup.rb
+++ b/test/vcr_setup.rb
@@ -1,5 +1,6 @@
 require 'vcr'
 require 'webmock/minitest'
+require 'addressable'
 
 # VCR records HTTP interactions to cassettes that can be replayed during unit tests
 # allowing for faster, more predictible web interactions
@@ -14,7 +15,7 @@ VCR.configure do |c|
   ENV['VSAC_API_KEY'] = "vcrpass" unless ENV['VSAC_API_KEY']
 
   # Ensure plain text passwords do not show up during logging
-  c.filter_sensitive_data('<VSAC_API_KEY>') {URI.escape(ENV['VSAC_API_KEY'])}
+  c.filter_sensitive_data('<VSAC_API_KEY>') { Addressable::URI.encode(ENV['VSAC_API_KEY']) }
   c.default_cassette_options = { record: :once }
 
   # Add a custom matcher for use with the bulk request by typheous, so we can ignore service ticket


### PR DESCRIPTION
MAT-2555 update parsers to use mongoid models v0.0.4

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
