### PR TITLE
MAT-2803

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,4 +165,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/lib/measure-loader/mat_measure_files.rb
+++ b/lib/measure-loader/mat_measure_files.rb
@@ -58,7 +58,7 @@ module Measures
             pn = Pathname(f.name)
             next if '__MACOSX'.in? pn.each_filename  # ignore anything in a __MACOSX folder
             next unless pn.basename.extname.in? ['.xml','.cql','.json','.html']
-            folders[pn.dirname][:files] << { basename: pn.basename, contents: f.get_input_stream.read }
+            folders[pn.dirname][:files] << { basename: pn.basename, contents: f.get_input_stream.read.force_encoding('UTF-8') }
             folders[pn.dirname][:depth] =  pn.each_filename.count # this is just a count of how many folders are in the path
           end
         end

--- a/test/unit/hqmf/parser_test.rb
+++ b/test/unit/hqmf/parser_test.rb
@@ -11,7 +11,7 @@ class ParseTest < Minitest::Test
   def test_basic_parse_v1
 
     parsed = HQMF::Parser::V1Parser.new.parse(@hqmf_contents_v1)
-    parsed.title.must_equal "Pneumonia Vaccination Status for Older Adults (NQF 0043)"
+    _(parsed.title).must_equal "Pneumonia Vaccination Status for Older Adults (NQF 0043)"
 
   end
 
@@ -19,7 +19,7 @@ class ParseTest < Minitest::Test
 
     parsed = HQMF::Parser::V2Parser.new.parse(@hqmf_contents_v2)
 
-    parsed.title.must_equal "Statin Prescribed at Discharge"
+    _(parsed.title).must_equal "Statin Prescribed at Discharge"
   end
 
 end

--- a/test/vcr_setup.rb
+++ b/test/vcr_setup.rb
@@ -1,5 +1,6 @@
 require 'vcr'
 require 'webmock/minitest'
+require 'addressable'
 
 # VCR records HTTP interactions to cassettes that can be replayed during unit tests
 # allowing for faster, more predictible web interactions
@@ -14,7 +15,7 @@ VCR.configure do |c|
   ENV['VSAC_API_KEY'] = "vcrpass" unless ENV['VSAC_API_KEY']
 
   # Ensure plain text passwords do not show up during logging
-  c.filter_sensitive_data('<VSAC_API_KEY>') {URI.escape(ENV['VSAC_API_KEY'])}
+  c.filter_sensitive_data('<VSAC_API_KEY>') { Addressable::URI.encode(ENV['VSAC_API_KEY']) }
   c.default_cassette_options = { record: :once }
 
   # Add a custom matcher for use with the bulk request by typheous, so we can ignore service ticket


### PR DESCRIPTION
MAT-2803 Update Bonnie to support UTF8 - QDM

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
