### PR TITLE
Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :development_group => :test
 
-gem 'mongoid', '~> 6.4.2'
+gem 'mongoid', '~> 7.0.5'
 
 # gem 'cqm-models', '~> 3.0.0'
 # gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '3.1.1.0'
+  s.version = '3.2.0.0'
 
   s.add_dependency 'cqm-models', '~> 3.0'
   s.add_dependency 'mustache'

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -11,12 +11,12 @@ Gem::Specification.new do |s|
 
   s.version = '3.1.1.0'
 
-  s.add_dependency 'cqm-models', '~> 3.0.0'
+  s.add_dependency 'cqm-models', '~> 3.0'
   s.add_dependency 'mustache'
   s.add_dependency 'erubis', '~> 2.7.0'
-  s.add_dependency 'mongoid', '~> 6.4'
+  s.add_dependency 'mongoid', '~> 7.0.5'
   s.add_dependency 'mongoid-tree', '~> 2.1'
-  s.add_dependency 'activesupport', '~> 5.0'
+  s.add_dependency 'activesupport', '~> 6.0'
 
   s.add_dependency 'protected_attributes_continued', '~> 1.4.0'
   s.add_dependency 'uuid', '~> 2.3.7'


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
