### PR TITLE
MAT-2867 add uuid for drc url

### DIFF
--- a/lib/measure-loader/value_set_helpers.rb
+++ b/lib/measure-loader/value_set_helpers.rb
@@ -53,7 +53,8 @@ module Measures
                 title: FHIR::PrimitiveString.transform_json(code_reference['display'], nil),
                 version: FHIR::PrimitiveString.new(value: ''),
                 compose: vs_compose,
-                fhirId: code_hash
+                fhirId: code_hash,
+                url: FHIR::PrimitiveUri.transform_json("urn:uuid:#{SecureRandom.uuid}", nil)
               )
             end
             value_sets_from_single_code_references << vs_model_cache[cache_key]


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
