### PR TITLE
MAT-3265 Set Measurement Period seconds values to zero

### DIFF
--- a/lib/util/bundle_utils.rb
+++ b/lib/util/bundle_utils.rb
@@ -29,10 +29,10 @@ module FHIR
         end
       mp[:end] =
         if fhir_measure.effectivePeriod.end&.value
-          fhir_measure.effectivePeriod.end.value << "T23:59:59"
+          fhir_measure.effectivePeriod.end.value << "T23:59:00"
         else
           # Default measurement period end
-          mp[:end] = '2019-12-31T23:59:59'
+          mp[:end] = '2019-12-31T23:59:00'
         end
       mp
     end


### PR DESCRIPTION
Since Bonnie cannot create patient dateTime data with seconds, always set the measurement period seconds (milli) values to zero to ensure compatible comparisons.

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: [MAT-3265](https://jira.cms.gov/browse/MAT-3265)
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
