### PR TITLE
Bump Nokogiri to Resolve CVE-2021-41098 (bonnie-on-fhir)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       mongoid (~> 7.1.2)
       mongoid-tree (~> 2.1.0)
       mustache
-      nokogiri (>= 1.11.5, < 1.11.7)
+      nokogiri (~> 1.12)
       rubyzip (~> 1.3)
       typhoeus
       uuid (~> 2.3.7)
@@ -55,7 +55,7 @@ GEM
       ffi (>= 1.15.0)
     factory_girl (4.1.0)
       activesupport (>= 3.0.0)
-    ffi (1.15.3)
+    ffi (1.15.4)
     fhir-mongoid-models (0.0.4)
     hashdiff (1.0.1)
     highline (1.7.10)
@@ -68,7 +68,7 @@ GEM
       systemu (~> 2.6.5)
     memoist (0.9.3)
     method_source (0.9.2)
-    mini_portile2 (2.5.3)
+    mini_portile2 (2.6.1)
     minitest (5.14.1)
     minitest-reporters (1.4.2)
       ansi
@@ -83,8 +83,8 @@ GEM
     mongoid-tree (2.1.1)
       mongoid (>= 4.0, < 8)
     mustache (1.1.1)
-    nokogiri (1.11.6)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     parallel (1.19.2)
     parser (2.7.2.0)

--- a/cqm-parsers.gemspec
+++ b/cqm-parsers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'uuid', '~> 2.3.7'
   s.add_dependency 'builder', '~> 3.1'
-  s.add_dependency 'nokogiri', '>= 1.11.5', '< 1.11.7'
+  s.add_dependency 'nokogiri', '~> 1.12'
   s.add_dependency 'highline', "~> 1.7.0"
 
   s.add_dependency 'rubyzip', '~> 1.3'


### PR DESCRIPTION
Bump Nokogiri to 1.12.5 to resolve security vuln. See [Improper Restriction of XML External Entity Reference (XXE) in Nokogiri on JRuby](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2rr5-8q37-2w7h) for more info.

This bump may not be needed since the vulnerability is currently reported to only affect JRuby.


Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
