### PR TITLE
MAT-3708 Update CQM-Parser to Account for Comments in the ELM (#163)

### DIFF
--- a/lib/measure-loader/elm_parser.rb
+++ b/lib/measure-loader/elm_parser.rb
@@ -12,14 +12,17 @@ module Measures
       # extract library identifier data
       ret[:identifier][:id] = doc.css("identifier").attr("id").value
       ret[:identifier][:version] = doc.css("identifier").attr("version").value
-
-      # extracts the fields of type "annotation" and their children.
-      annotations = doc.css("annotation")
-      annotations.each do |node|
-        node, define_name = parse_node(node, localid_to_type_map)
-        unless define_name.nil?
-          node[:define_name] = define_name
-          ret[:statements] << node
+      # all the define statements including functions
+      definitions = doc.css("statements def")
+      definitions&.each do |definition|
+        annotation = definition.at("annotation")
+        if annotation
+          node = parse_node(annotation, localid_to_type_map)
+          define_name = definition.attr("name")
+          unless define_name.nil?
+            node[:define_name] = define_name
+            ret[:statements] << node
+          end
         end
       end
       ret
@@ -31,7 +34,6 @@ module Measures
       ret = {
         children: []
       }
-      define_name = nil
       node.children.each do |child|
         if child.is_a?(Nokogiri::XML::Text) # leaf node
           clause_text = child.content.gsub(/\t/, "  ")
@@ -40,19 +42,17 @@ module Measures
           }
           clause[:ref_id] = child['r'] unless child['r'].nil?
           ret[:children] << clause
-          define_name = clause_text.split("\"")[1] if clause_text.strip.starts_with?("define")
         else
           node_type = localid_to_type_map[child['r']] unless child['r'].nil?
           # Parses the current child recursively. child_define_name will bubble up to indicate which
           # statement is currently being traversed.
-          node, child_define_name = parse_node(child, localid_to_type_map)
+          node = parse_node(child, localid_to_type_map)
           node[:node_type] = node_type  unless node_type.nil?
           node[:ref_id] = child['r'] unless child['r'].nil?
           ret[:children] << node
-          define_name = child_define_name unless child_define_name.nil?
         end
       end
-      return ret, define_name
+      return ret
     end
 
     def self.generate_localid_to_type_map(doc)

--- a/test/fixtures/measureloading/elm_xmls/AntithromboticTherapyByEndofHospitalDay2.xml
+++ b/test/fixtures/measureloading/elm_xmls/AntithromboticTherapyByEndofHospitalDay2.xml
@@ -207,7 +207,7 @@
       <def localId="37" locator="36:1-37:40" name="Numerator" context="Patient" accessLevel="Public">
          <annotation xsi:type="a:Annotation">
             <a:s r="37">
-               <a:s>define &quot;Numerator&quot;:
+               <a:s>/*this is NUMER*/define &quot;Numerator&quot;:
 	</a:s>
                <a:s r="36">
                   <a:s>&quot;Encounter with Antithrombotic Therapy&quot;</a:s>
@@ -685,7 +685,7 @@
       <def localId="113" locator="53:1-54:49" name="Initial Population" context="Patient" accessLevel="Public">
          <annotation xsi:type="a:Annotation">
             <a:s r="113">
-               <a:s>define &quot;Initial Population&quot;:
+               <a:s>//this is IPPdefine &quot;Initial Population&quot;:
 	</a:s>
                <a:s r="112">
                   <a:s r="111">

--- a/test/fixtures/measureloading/elm_xmls/AntithromboticTherapyByEndofHospitalDay2_Annotations.json
+++ b/test/fixtures/measureloading/elm_xmls/AntithromboticTherapyByEndofHospitalDay2_Annotations.json
@@ -492,7 +492,7 @@
             {
               "children": [
                 {
-                  "text": "define \"Numerator\":\n  "
+                  "text": "/*this is NUMER*/define \"Numerator\":\n  "
                 }
               ]
             },
@@ -1782,7 +1782,7 @@
             {
               "children": [
                 {
-                  "text": "define \"Initial Population\":\n  "
+                  "text": "//this is IPPdefine \"Initial Population\":\n  "
                 }
               ]
             },

--- a/test/unit/measure-loader/elm_parser_test.rb
+++ b/test/unit/measure-loader/elm_parser_test.rb
@@ -27,8 +27,7 @@ class ElmParserTest < Minitest::Test
         </a>
       </a>'
     doc = Nokogiri::XML(xml) { |config| config.noblanks }
-    ret, define_name = Measures::ElmParser.parse_node(doc, {})
-    assert_equal 'SDE Ethnicity', define_name
+    ret = Measures::ElmParser.parse_node(doc, {})
     expected_ret =
       {
         children:


### PR DESCRIPTION
* MAT-3708 Update CQM-Parser to Account for Comments in the ELM

* MAT-3708 display commented functions and defs

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
