### PR TITLE
[MAT-6046] Update VSAC Connection to use UMLS API KEY in Requests - Bonnie FHIR

### DIFF
--- a/lib/measure-loader/vsac_value_set_loader.rb
+++ b/lib/measure-loader/vsac_value_set_loader.rb
@@ -7,8 +7,7 @@ module Measures
     def initialize(options)
       options.symbolize_keys!
       @vsac_options = options[:options]
-      @vsac_ticket_granting_ticket = options[:ticket_granting_ticket]
-      @vsac_api_key = options[:api_key]
+      @vsac_api_key = options[:vsac_api_key]
       @vs_model_cache = {}
     end
 
@@ -49,7 +48,7 @@ module Measures
 
     def load_api
       return @api if @api.present?
-      @api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], ticket_granting_ticket: @vsac_ticket_granting_ticket, api_key: @vsac_api_key)
+      @api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: @vsac_api_key)
       return @api
     end
 

--- a/lib/util/vsac_api.rb
+++ b/lib/util/vsac_api.rb
@@ -40,13 +40,6 @@ module Util
       end
     end
 
-    # Raised when the ticket granting ticket has expired.
-    class VSACTicketExpiredError < VSACError
-      def initialize
-        super('VSAC session expired. Please re-enter credentials and try again.')
-      end
-    end
-
     # Raised when the user credentials were invalid.
     class VSACInvalidCredentialsError < VSACError
       def initialize

--- a/lib/util/vsac_api.rb
+++ b/lib/util/vsac_api.rb
@@ -84,6 +84,16 @@ module Util
           raise VSACArgumentError.new("Required param :config is missing required URLs.")
         end
         @api_key = options[:api_key]
+        validate_api_key_vsac unless options[:api_key].nil?
+      end
+
+      ##
+      # Attempt to retrieve the ONC Admin Sex VS to verify
+      # VSAC connectivity with the supplied UMLS API Key.
+      def validate_api_key_vsac
+        response = get_multiple_valueset_raw_responses([{value_set: {oid: "2.16.840.1.113762.1.4.1"}, vs_vsac_options: {}}])[0]
+        raise VSACInvalidCredentialsError.new if !response.body || response.response_code == 401
+        validate_http_status(response.response_code)
       end
 
       ##

--- a/test/fixtures/vcr_cassettes/measure__test_can_use_cache.yml
+++ b/test/fixtures/vcr_cassettes/measure__test_can_use_cache.yml
@@ -98,7 +98,7 @@ http_interactions:
   recorded_at: Thu, 15 Apr 2021 14:29:57 GMT
 - request:
     method: get
-    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113883.3.117.1.7.1.292&profile=MU2%20Update%202016-04-01&ticket=ST-3358317-wQErFnhqppm92Inpfnbr-cas
+    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113883.3.117.1.7.1.292&profile=MU2%20Update%202016-04-01
     body:
       encoding: US-ASCII
       string: ''

--- a/test/fixtures/vcr_cassettes/vsac_vs_include_draft_with_profile.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_include_draft_with_profile.yml
@@ -100,7 +100,7 @@ http_interactions:
   recorded_at: Fri, 11 Jan 2019 18:37:05 GMT
 - request:
     method: get
-    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113762.1.4.1&includeDraft=yes&profile=eCQM%20Update%202018-05-04&ticket=ST-610-M2bVx625taemBH1KR6ag-cas
+    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113762.1.4.1&includeDraft=yes&profile=eCQM%20Update%202018-05-04
     body:
       encoding: US-ASCII
       string: ''

--- a/test/fixtures/vcr_cassettes/vsac_vs_no_options.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_no_options.yml
@@ -100,7 +100,7 @@ http_interactions:
   recorded_at: Fri, 11 Jan 2019 18:37:07 GMT
 - request:
     method: get
-    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113762.1.4.1&ticket=ST-612-yHRoge9YvaXxzxay16pI-cas
+    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113762.1.4.1
     body:
       encoding: US-ASCII
       string: ''

--- a/test/fixtures/vcr_cassettes/vsac_vs_not_found.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_not_found.yml
@@ -100,7 +100,7 @@ http_interactions:
   recorded_at: Fri, 11 Jan 2019 18:37:04 GMT
 - request:
     method: get
-    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=bad.oid&ticket=ST-609-2FY145VcHOngyadpaOog-cas
+    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=bad.oid
     body:
       encoding: US-ASCII
       string: ''

--- a/test/fixtures/vcr_cassettes/vsac_vs_release.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_release.yml
@@ -100,7 +100,7 @@ http_interactions:
   recorded_at: Fri, 11 Jan 2019 18:37:05 GMT
 - request:
     method: get
-    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113762.1.4.1&release=MU2%20EP%20Update%202014-05-30&ticket=ST-611-0jmBZLkRouloNavkJi0P-cas
+    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113762.1.4.1&release=MU2%20EP%20Update%202014-05-30
     body:
       encoding: US-ASCII
       string: ''

--- a/test/fixtures/vcr_cassettes/vsac_vs_version.yml
+++ b/test/fixtures/vcr_cassettes/vsac_vs_version.yml
@@ -100,7 +100,7 @@ http_interactions:
   recorded_at: Fri, 11 Jan 2019 18:37:08 GMT
 - request:
     method: get
-    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113883.3.600.1.1834&ticket=ST-613-BwS0ROad0P4yf1KnwZcG-cas&version=MU2%20EP%20Update%202014-07-01
+    uri: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets?id=2.16.840.1.113883.3.600.1.1834&version=MU2%20EP%20Update%202014-07-01
     body:
       encoding: US-ASCII
       string: ''

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -113,7 +113,6 @@ APP_CONFIG = {'vsac'=> {'auth_url'=> 'https://vsac.nlm.nih.gov/vsac/ws',
                         'utility_url' => 'https://vsac.nlm.nih.gov/vsac',
                         'default_profile' => 'MU2 Update 2016-04-01'}}
 
-def get_ticket_granting_ticket_using_env_vars
-  api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
-  return api.ticket_granting_ticket
+def test_api_key
+  "apiKeyThing"
 end

--- a/test/unit/measure-loader/bundle_loader_composite_test.rb
+++ b/test/unit/measure-loader/bundle_loader_composite_test.rb
@@ -16,7 +16,7 @@ class BundleLoaderTest < Minitest::Test
     skip "Bonnie-on-FHIR does not support composite measures."
     VCR.use_cassette('measure__test_invalid_composite_measure_with_component_measure_missing_xml_file', @vcr_options) do
       measure_file = File.new File.join(@fixtures_path, 'CMSAWA_v5_6_Artifacts_missing_file.zip')
-      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
       loader = Measures::BundleLoader.new(measure_file, @measure_details, value_set_loader)
       assert_raises Measures::MeasureLoadingInvalidPackageException do
         loader.extract_measures
@@ -28,7 +28,7 @@ class BundleLoaderTest < Minitest::Test
     skip "Bonnie-on-FHIR does not support composite measures."
     VCR.use_cassette('measure__invalid_composite_measure_with_missing_component_measure', @vcr_options) do
       measure_file = File.new File.join(@fixtures_path, 'CMSAWA_v5_6_Artifacts_missing_component.zip')
-      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
       loader = Measures::BundleLoader.new(measure_file, @measure_details, value_set_loader)
       assert_raises Measures::MeasureLoadingInvalidPackageException do
         loader.extract_measures
@@ -40,7 +40,7 @@ class BundleLoaderTest < Minitest::Test
     skip "Bonnie-on-FHIR does not support composite measures."
     VCR.use_cassette('measure__invalid_composite_measure_with_missing_composite_measure_files', @vcr_options) do
       measure_file = File.new File.join(@fixtures_path, 'CMSAWA_v5_6_Artifacts_missing_composite_files.zip')
-      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
       loader = Measures::BundleLoader.new(measure_file, @measure_details, value_set_loader)
       assert_raises Measures::MeasureLoadingInvalidPackageException do
         loader.extract_measures
@@ -52,7 +52,7 @@ class BundleLoaderTest < Minitest::Test
     skip "Bonnie-on-FHIR does not support composite measures."
     VCR.use_cassette('measure__load_composite_measure', @vcr_options) do
       measure_file = File.new File.join(@fixtures_path, 'CMSAWA_v5_6_Artifacts.zip')
-      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
       loader = Measures::BundleLoader.new(measure_file, @measure_details, value_set_loader)
       measures = loader.extract_measures
       assert_equal 8, measures.length

--- a/test/unit/measure-loader/bundle_loader_test.rb
+++ b/test/unit/measure-loader/bundle_loader_test.rb
@@ -15,7 +15,7 @@ class BundleLoaderTest < Minitest::Test
   def test_extract_measure
     VCR.use_cassette('vsac_response_for_load_CMS104', @vcr_options) do
       measure_file = File.new File.join(@fixtures_path, 'CMS104_v6_0_fhir_Artifacts.zip')
-      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
       loader = Measures::BundleLoader.new(measure_file, @measure_details, value_set_loader)
       measure = loader.extract_measure
 
@@ -108,7 +108,7 @@ class BundleLoaderTest < Minitest::Test
       measure_details = { 'episode_of_care'=> true, 'continuous_variable' => true }
       measure_file = File.new File.join(@fixtures_path, ['CMS111Test', 'CMS111Test_v6_02_Artifacts.zip'])
 
-      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+      value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
       loader = Measures::BundleLoader.new(measure_file, measure_details, value_set_loader)
       measure = loader.extract_measure
 
@@ -168,7 +168,7 @@ class BundleLoaderTest < Minitest::Test
   #     measure_details = { 'episode_of_care'=> true, 'continuous_variable' => true, 'population_titles' => ['ps1','ps2','ps1strat1','ps1strat2','ps2strat1'] }
   #     measure_file = File.new File.join(@fixtures_path, 'CMS137v7.zip')
   #
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     assert_equal 1, measures.length
@@ -187,7 +187,7 @@ class BundleLoaderTest < Minitest::Test
   #   VCR.use_cassette('measure__definition_with_same_name_as_a_library_definition', @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'CMS134v6.zip')
   #
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     assert_equal 1, measures.length
@@ -205,7 +205,7 @@ class BundleLoaderTest < Minitest::Test
   # def test_source_data_criteria_creation
   #   VCR.use_cassette('measure__source_data_criteria_creation', @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'CMS134v6.zip')
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     assert_equal 1, measures.length
@@ -264,7 +264,7 @@ class BundleLoaderTest < Minitest::Test
   #
   #   ['1','2'].each do |cassette_number|
   #     VCR.use_cassette('measure__direct_reference_code_handles_creation_of_codeListId_hash'+cassette_number, @vcr_options) do
-  #       value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #       value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
   #       loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #       measures = loader.extract_measures
   #       measure = measures[0]
@@ -278,7 +278,7 @@ class BundleLoaderTest < Minitest::Test
   # def test_unique_characters_stored_correctly
   #   VCR.use_cassette('measure__unique_characters_stored_correctly', @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'TOB2_v5_5_Artifacts.zip')
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options_w_draft, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options_w_draft, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     measure = measures[0]
@@ -297,7 +297,7 @@ class BundleLoaderTest < Minitest::Test
   # def test_measure_including_draft
   #   VCR.use_cassette("measure__measure_including_draft", @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'DRAFT_CMS2_CQL.zip')
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options_w_draft, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options_w_draft, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     measure = measures[0]
@@ -316,7 +316,7 @@ class BundleLoaderTest < Minitest::Test
   # def test_measure
   #   VCR.use_cassette("measure__test_measure", @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'CMS137v7.zip')
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options_w_draft, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options_w_draft, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     measure = measures[0]
@@ -332,7 +332,7 @@ class BundleLoaderTest < Minitest::Test
   # def test_5_4_CQL_measure
   #   VCR.use_cassette("measure__test_5_4_CQL_measure", @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'CMS158_v5_4_Artifacts.zip')
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     measure = measures[0]
@@ -349,7 +349,7 @@ class BundleLoaderTest < Minitest::Test
   # def test_proportional_cv_measure
   #   VCR.use_cassette("measure__test_ratio_cv_measure", @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'HyperG_v5_6_Artifacts.zip')
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     measure = measures[0]
@@ -361,7 +361,7 @@ class BundleLoaderTest < Minitest::Test
   # def test_ratio_cv_measure
   #   VCR.use_cassette("measure__test_proportional_cv_measure", @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'CVmulti_v5_6_Artifacts.zip')
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     measure = measures[0]
@@ -373,7 +373,7 @@ class BundleLoaderTest < Minitest::Test
   # def test_multiple_libraries
   #   VCR.use_cassette("measure__test_multiple_libraries", @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'bonnienesting01_updated.zip')
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     measure = measures[0]
@@ -429,7 +429,7 @@ class BundleLoaderTest < Minitest::Test
   # def test_negated_source_criteria_with_drc
   #   VCR.use_cassette('measure__negated_source_criteria_with_drc', @vcr_options) do
   #     measure_file = File.new File.join(@fixtures_path, 'CMS22v7.zip')
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: @vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::CqlLoader.new(measure_file, @measure_details, value_set_loader)
   #     measures = loader.extract_measures
   #     assert_equal 1, measures.length

--- a/test/unit/measure-loader/bundle_loader_test.rb
+++ b/test/unit/measure-loader/bundle_loader_test.rb
@@ -24,7 +24,7 @@ class BundleLoaderTest < Minitest::Test
       assert_equal '42BF391F-38A3-4C0F-9ECE-DCD47E9609D9', measure.set_id, 'Measure set Id does not match expected value.'
       assert_equal 'PATIENT', measure.calculation_method, "Did not correctly determine the main measure library name."
       assert_equal '2021-01-01T00:00:00', measure.measure_period[:start], "Measurement period start date mismatch"
-      assert_equal '2021-12-31T23:59:59', measure.measure_period[:end], "Measurement period end date mismatch"
+      assert_equal '2021-12-31T23:59:00', measure.measure_period[:end], "Measurement period end date mismatch"
       assert_equal 5, measure.libraries.size, 'Mismatching library size.'
       # Not sure whether this association was a hmbt at one point or if this was never passing, but
       # value_set_ids doesn't come with the embeds_many :value_sets relation.

--- a/test/unit/measure-loader/value_set_loader_test.rb
+++ b/test/unit/measure-loader/value_set_loader_test.rb
@@ -17,7 +17,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   def test_can_use_cache
     VCR.use_cassette('measure__test_can_use_cache') do
       vsac_options = { profile: APP_CONFIG['vsac']['default_profile'] }
-      vs_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+      vs_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
       needed_value_sets = [{oid: "2.16.840.1.113883.3.117.1.7.1.292", version: nil, profile: nil}]
 
       valuesets = vs_loader.retrieve_and_modelize_value_sets_from_vsac(needed_value_sets, {})
@@ -34,7 +34,7 @@ class VSACValueSetLoaderTest < Minitest::Test
     # Expects that draft and default profile will be used
     VCR.use_cassette('vs_loading_draft_profile_CMS104', @vcr_options) do
       vsac_options = { profile: APP_CONFIG['vsac']['default_profile'], include_draft: true }
-      value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+      value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
       loader = Measures::BundleLoader.new(@measure_file_base, @empty_measure_details, value_set_loader)
       measure = loader.extract_measure
       value_sets = measure.value_sets.select { |vs| vs.fhirId == '2.16.840.1.113883.3.117.1.7.1.93'}
@@ -53,7 +53,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   #   # Expects that draft and default profile will be used, and provided Profile will be ignored
   #   VCR.use_cassette('vs_loading_draft_profile', @vcr_options) do
   #     vsac_options = { profile: APP_CONFIG['vsac']['default_profile'], include_draft: true }
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::BundleLoader.new(@measure_file_with_profiles, @empty_measure_details, value_set_loader)
   #     measure = loader.extract_measures[0]
   #     assert_equal 165, measure.value_sets.select { |vs| vs.oid == "2.16.840.1.113883.3.600.1.1834"}[0].concepts.size
@@ -64,7 +64,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   #   VCR.use_cassette('vs_loading_draft_verion',
   #                    match_requests_on: [:method, :uri_no_st]) do
   #     vsac_options = { profile: APP_CONFIG['vsac']['default_profile'], include_draft: true }
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::BundleLoader.new(@measure_file_version, @empty_measure_details, value_set_loader)
   #     measure = loader.extract_measures[0]
   #     assert_equal 165, measure.value_sets.select { |vs| vs.oid == "2.16.840.1.113883.3.600.1.1834"}[0].concepts.size
@@ -74,7 +74,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   # def test_loading_without_includedraft_and_no_profile_or_version
   #   VCR.use_cassette('vs_loading_no_profile_version', @vcr_options) do
   #     vsac_options = { profile: APP_CONFIG['vsac']['default_profile'] }
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::BundleLoader.new(@measure_file_version, @empty_measure_details, value_set_loader)
   #     measure = loader.extract_measures[0]
   #     assert_equal 165, measure.value_sets.select { |vs| vs.oid == "2.16.840.1.113883.3.600.1.1834"}[0].concepts.size
@@ -85,7 +85,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   #   VCR.use_cassette('vs_loading_meausre_defined_no_backup_profile', @vcr_options) do
   #     vsac_options = { measure_defined: true }
   #
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::BundleLoader.new(@measure_file_base, @empty_measure_details, value_set_loader)
   #     measure = loader.extract_measures[0]
   #     assert_equal 173, measure.value_sets.select { |vs| vs.oid == "2.16.840.1.113883.3.600.1.1834"}[0].concepts.size
@@ -95,7 +95,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   # def test_loading_with_release
   #   VCR.use_cassette('vs_loading_release', @vcr_options) do
   #     vsac_options = { release: 'eCQM Update 2018 EP-EC and EH' }
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::BundleLoader.new(@measure_file_base, @empty_measure_details, value_set_loader)
   #     measure = loader.extract_measures[0]
   #     assert_equal 162, measure.value_sets.select { |vs| vs.oid == "2.16.840.1.113883.3.600.1.1834"}[0].concepts.size
@@ -115,7 +115,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   # def test_loading_measure_defined_value_sets_defined_by_profile
   #   VCR.use_cassette('vs_loading_profile', @vcr_options) do
   #     vsac_options = { measure_defined: true }
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::BundleLoader.new(@measure_file_with_profiles, @empty_measure_details, value_set_loader)
   #     measure = loader.extract_measures[0]
   #     assert_equal 163, measure.value_sets.select { |vs| vs.oid == "2.16.840.1.113883.3.600.1.1834"}[0].concepts.size
@@ -125,7 +125,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   # def test_loading_measure_defined_value_sets_defined_by_version
   #   VCR.use_cassette('vs_loading_version', @vcr_options) do
   #     vsac_options = { measure_defined: true }
-  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #     value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
   #     loader = Measures::BundleLoader.new(@measure_file_version, @empty_measure_details, value_set_loader)
   #     measure = loader.extract_measures[0]
   #     assert_equal 148, measure.value_sets.select { |vs| vs.oid == "2.16.840.1.113883.3.600.1.1834"}[0].concepts.size
@@ -140,7 +140,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   #     vsac_options = { profile: 'Latest eCQM', include_draft: true }
   #
   #     error = assert_raises Util::VSAC::VSEmptyError do
-  #       value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #       value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
   #       value_set_loader.retrieve_and_modelize_value_sets_from_vsac(value_sets)
   #     end
   #     assert_equal '2.16.840.1.113762.1.4.1179.2', error.oid
@@ -153,7 +153,7 @@ class VSACValueSetLoaderTest < Minitest::Test
   #     vsac_options = { profile: 'Latest eCQM', include_draft: true }
   #
   #     error = assert_raises Util::VSAC::VSNotFoundError do
-  #       value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, ticket_granting_ticket: get_ticket_granting_ticket_using_env_vars)
+  #       value_set_loader = Measures::VSACValueSetLoader.new(options: vsac_options, vsac_api_key: test_api_key)
   #       value_set_loader.retrieve_and_modelize_value_sets_from_vsac(value_sets)
   #     end
   #     assert_equal '2.16.840.1.113762.1.4.1179.2f', error.oid

--- a/test/unit/vsac/vsac_api_auth_test.rb
+++ b/test/unit/vsac/vsac_api_auth_test.rb
@@ -5,21 +5,10 @@ require 'util/vsac_api.rb'
 # Tests that ensure VSAC authentication related situations are handled
 class VSACAPIAuthTest < Minitest::Test
 
-  def test_valid_username_and_password_provided_does_not_raise
+  def test_valid_apikey_provided_does_not_raise
     VCR.use_cassette("vsac_auth_good_credentials") do
       api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: ENV['VSAC_API_KEY'])
-      assert api.ticket_granting_ticket
-      assert api.ticket_granting_ticket[:ticket]
-      assert api.ticket_granting_ticket[:expires]
-    end
-  end
-
-  def test_invalid_username_and_password_provided
-    VCR.use_cassette("vsac_auth_bad_credentials") do
-      assert_raises Util::VSAC::VSACInvalidCredentialsError do
-        api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], api_key: 'badkey')
-        assert api
-      end
+      assert api
     end
   end
 
@@ -30,66 +19,5 @@ class VSACAPIAuthTest < Minitest::Test
     assert_raises Util::VSAC::VSACNoCredentialsError do
       api.get_valueset('2.16.840.1.113762.1.4.1')
     end
-  end
-
-  def test_valid_ticket_granting_ticket_provided_and_used
-    VCR.use_cassette("vsac_auth_good_credentials_and_simple_call") do
-      api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'],
-                                    api_key: ENV['VSAC_API_KEY'])
-      assert api.ticket_granting_ticket
-
-      reused_ticket_granting_ticket = {
-        ticket: api.ticket_granting_ticket[:ticket],
-        expires: api.ticket_granting_ticket[:expires]
-      }
-
-      new_api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'],
-                                        ticket_granting_ticket: reused_ticket_granting_ticket)
-      assert new_api
-      valueset = api.get_valueset('2.16.840.1.113762.1.4.1')
-      assert valueset
-    end
-  end
-
-  def test_ticket_granting_ticket_provided_is_missing_or_missing_fields
-    assert_raises Util::VSAC::VSACArgumentError do
-      Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], ticket_granting_ticket: {})
-    end
-
-    missing_ticket = { expires: Time.now + 2.hours }
-    assert_raises Util::VSAC::VSACArgumentError do
-      Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], ticket_granting_ticket: missing_ticket)
-    end
-
-    missing_expires = { ticket: "ImATicketGrantingTicket" }
-    assert_raises Util::VSAC::VSACArgumentError do
-      Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], ticket_granting_ticket: missing_expires)
-    end
-
-    # nil, this shouln't throw an error, It will assume no credentials provided
-    Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'], ticket_granting_ticket: nil)
-  end
-
-  def test_ticket_granting_ticket_provided_expires_time_has_expired
-    assert_raises Util::VSAC::VSACTicketExpiredError do
-      Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'],
-                              ticket_granting_ticket: { ticket: "ImATicketGrantingTicket",
-                                                        expires: Time.now - 10.minutes })
-    end
-  end
-
-  def test_ticket_granting_ticket_provided_ticket_is_bad
-    api = Util::VSAC::VSACAPI.new(config: APP_CONFIG['vsac'],
-                                  ticket_granting_ticket: { ticket: "ImABadTicketGrantingTicket",
-                                                            expires: Time.now + 10.minutes })
-
-    VCR.use_cassette("vsac_auth_bad_ticket") do
-      assert_raises Util::VSAC::VSACTicketExpiredError do
-        api.get_valueset('2.16.840.1.113762.1.4.1')
-      end
-    end
-
-    # make sure the API has marked the ticket expired
-    assert_equal true, api.ticket_granting_ticket[:expires] <= Time.now
   end
 end


### PR DESCRIPTION
VSAC is dropping support for its TGT/ST based authn flow. Instead, VSAC SVS API will support Basic Authentication in requests with the password set to the requester's UMLS API KEY.

- Replace TGT/ST authn flow with Basic Authn containing the umls api key.
- Update test to reflect default MP end dateTime having 00 seconds

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: [MAT-6046](https://jira.cms.gov/browse/MAT-6046)
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
